### PR TITLE
AA: support file measurement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,7 @@ dependencies = [
  "crypto",
  "env_logger 0.11.6",
  "eventlog-rs",
+ "glob",
  "hex",
  "kbs-types",
  "kbs_protocol",
@@ -2424,9 +2425,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "group"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ config = "0.14.1"
 const_format = "0.2.34"
 ctr = "0.9.2"
 env_logger = "0.11.6"
+glob = "0.3.2"
 hex = "0.4.3"
 hmac = "0.12.1"
 jwt-simple = { version = "0.12", default-features = false, features = [

--- a/attestation-agent/attestation-agent/Cargo.toml
+++ b/attestation-agent/attestation-agent/Cargo.toml
@@ -45,6 +45,7 @@ tokio = { workspace = true, features = ["fs", "sync"] }
 toml.workspace = true
 tonic = { workspace = true, optional = true }
 ttrpc = { workspace = true, features = ["async"], optional = true }
+glob.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true

--- a/attestation-agent/attestation-agent/config.example.json
+++ b/attestation-agent/attestation-agent/config.example.json
@@ -12,5 +12,15 @@
         "eventlog_algorithm": "sha384",
         "init_pcr": 17,
         "enable_eventlog": false
+    },
+    "file_measurement_config": {
+        "enable": false,
+        "mode": "init_only",
+        "pcr_index": 17,
+        "domain": "file",
+        "operation": "measure",
+        "files": [
+            "/etc/attestation-agent.conf"
+        ]
     }
 }

--- a/attestation-agent/attestation-agent/config.example.toml
+++ b/attestation-agent/attestation-agent/config.example.toml
@@ -35,3 +35,24 @@ M9QaC1mzQ/OStg==
 eventlog_algorithm = "sha384"
 init_pcr = 17
 enable_eventlog = false
+
+[file_measurement_config]
+enable = false
+# always/init_only
+mode = "init_only"
+pcr_index = 17
+domain = "file"
+operation = "measure"
+# List of files or glob patterns to measure
+# Supports glob patterns like:
+# - "*" for matching any sequence of characters
+# - "?" for matching a single character
+# - "[abc]" for matching any one character from the set
+files = [
+  "/etc/attestation-agent.conf",
+  "/etc/hosts",
+  "/etc/resolv.conf",
+  "/etc/*.conf",
+  "/etc/attestation-agent/*",
+  "/boot/vmlinuz-5.10.134-18.al8.x86_64"
+]

--- a/attestation-agent/attestation-agent/src/eventlog/file_measurement.rs
+++ b/attestation-agent/attestation-agent/src/eventlog/file_measurement.rs
@@ -1,0 +1,130 @@
+// Copyright (c) 2025 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::collections::HashSet;
+
+use anyhow::Result;
+use crypto::HashAlgorithm;
+use glob::glob;
+use log::{debug, info, warn};
+use tokio::sync::Mutex;
+
+use crate::config;
+use crate::eventlog::{Content, EventLog, LogEntry};
+
+pub struct FileMeasurer<'a> {
+    eventlog: &'a Mutex<EventLog>,
+    config: config::FileMeasurementConfig,
+    hash_alg: HashAlgorithm,
+}
+
+impl<'a> FileMeasurer<'a> {
+    pub fn new(
+        eventlog: &'a Mutex<EventLog>,
+        config: config::FileMeasurementConfig,
+        hash_alg: HashAlgorithm,
+    ) -> Self {
+        Self {
+            eventlog,
+            config,
+            hash_alg,
+        }
+    }
+
+    pub async fn measure_files_from_config(&self) -> Result<()> {
+        let pcr_index = self.config.pcr_index;
+        let domain = &self.config.domain;
+        let operation = &self.config.operation;
+
+        info!(
+            "Starting batch file measurement with PCR index: {}",
+            pcr_index
+        );
+
+        let mut measured_files = HashSet::new();
+
+        for pattern in &self.config.files {
+            debug!("Processing pattern: {}", pattern);
+
+            match glob(pattern) {
+                Ok(entries) => {
+                    for entry in entries {
+                        match entry {
+                            Ok(path) => {
+                                if path.is_file() {
+                                    let path_str = path.to_string_lossy().to_string();
+                                    if measured_files.insert(path_str.clone()) {
+                                        self.measure_single_file(
+                                            &path_str,
+                                            domain,
+                                            operation,
+                                            pcr_index,
+                                            self.hash_alg,
+                                        )
+                                        .await?;
+                                    } else {
+                                        debug!("Skipping already measured file: {}", path_str);
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                warn!(
+                                    "Error while accessing path matched by pattern '{}': {}",
+                                    pattern, e
+                                );
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!("Invalid glob pattern '{}': {}", pattern, e);
+                }
+            }
+        }
+
+        info!(
+            "Batch file measurement completed successfully. Measured {} unique files",
+            measured_files.len()
+        );
+        Ok(())
+    }
+
+    async fn measure_single_file(
+        &self,
+        file_path: &str,
+        domain: &str,
+        operation: &str,
+        pcr_index: u64,
+        hash_alg: HashAlgorithm,
+    ) -> Result<()> {
+        debug!("Measuring file: {}", file_path);
+        match tokio::fs::read(file_path).await {
+            Ok(content) => {
+                let file_hash = hash_alg.digest(&content);
+                let content_str = format!("{}:{}", file_path, hex::encode(file_hash));
+
+                debug!("Extending measurement for file: {}", file_path);
+
+                let content: Content = content_str.as_str().try_into()?;
+                let log_entry = LogEntry::Event {
+                    domain,
+                    operation,
+                    content,
+                };
+
+                self.eventlog
+                    .lock()
+                    .await
+                    .extend_entry(log_entry, pcr_index)
+                    .await?;
+            }
+            Err(e) => {
+                warn!("Failed to read file for measurement {}: {}", file_path, e);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/attestation-agent/attestation-agent/src/eventlog/mod.rs
+++ b/attestation-agent/attestation-agent/src/eventlog/mod.rs
@@ -4,6 +4,7 @@
 //
 
 pub mod event;
+pub mod file_measurement;
 
 use std::{
     fmt::Display,


### PR DESCRIPTION
This PR implements file measurement functionality in Attestation Agent, allowing automatic measurement of specified files and extending their hash values to PCR.
# Key Features
- Supports two measurement modes:
  - init_only: Measures files only when the event log is first created
  - always: Measures files on every startup
- Supports specifying files to measure using glob patterns for easy batch measurement
- Measurement results are recorded as events in the event log
- Feature can be enabled/disabled via configuration file
# Configuration Example
Added file_measurement_config section to configuration files (JSON or TOML):
```toml
[file_measurement_config]
enable = false
mode = "init_only"
pcr_index = 17
domain = "file"
operation = "measure"
files = [
  "/etc/attestation-agent.conf",
  "/etc/*.conf",
  "/boot/vmlinuz-*"
]
```
