### PR TITLE
ci: temporarily disable check link ci

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -10,19 +10,19 @@ on:
 jobs:
   checklinks:
     runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+    # steps:
+      # - name: Checkout code
+      #   uses: actions/checkout@v4
 
-      - name: Restore lychee cache
-        uses: actions/cache@v4
-        with:
-          path: .lycheecache
-          key: cache-lychee-${{ github.sha }}
-          restore-keys: cache-lychee-
+      # - name: Restore lychee cache
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: .lycheecache
+      #     key: cache-lychee-${{ github.sha }}
+      #     restore-keys: cache-lychee-
 
-      - name: Check links
-        uses: lycheeverse/lychee-action@v2
-        with:
-          args: "--cache --max-cache-age 1d ."
-          fail: true
+      # - name: Check links
+      #   uses: lycheeverse/lychee-action@v2
+      #   with:
+      #     args: "--cache --max-cache-age 1d ."
+      #     fail: true


### PR DESCRIPTION
this ci is broken due to upstream issues, let's disable it before it's good.