### PR TITLE
AA: fix dracut for non-tdx platforms

### DIFF
--- a/dist/dracut/modules.d/99attestation-agent/attestation-agent-platform-detect.service
+++ b/dist/dracut/modules.d/99attestation-agent/attestation-agent-platform-detect.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Attestation-Agent Detect Platform Attributes
+DefaultDependencies=no
+ConditionPathExists=/etc/initrd-release
+After=sysinit.target
+
+[Service]
+Type=oneshot
+ExecStart=bash /usr/bin/attestation-agent-platform-detect.sh
+RemainAfterExit=true

--- a/dist/dracut/modules.d/99attestation-agent/attestation-agent-platform-detect.sh
+++ b/dist/dracut/modules.d/99attestation-agent/attestation-agent-platform-detect.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -x
+set -e
+
+is_tdx_guest() {
+    if grep tdx_guest /proc/cpuinfo >/dev/null ; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+CONFIG_FILE="/etc/trustiflux/attestation-agent.toml"
+
+if is_tdx_guest; then
+    modprobe tdx-guest
+else
+    sed -i 's/enable_eventlog = true/enable_eventlog = false/' ${CONFIG_FILE}
+fi

--- a/dist/dracut/modules.d/99attestation-agent/attestation-agent.service
+++ b/dist/dracut/modules.d/99attestation-agent/attestation-agent.service
@@ -4,16 +4,15 @@ Documentation=https://confidentialcontainers.org
 DefaultDependencies=no
 ConditionPathExists=/etc/initrd-release
 After=sysinit.target
+After=attestation-agent-platform-detect.service
 Before=basic.target
+Requires=attestation-agent-platform-detect.service
 
 [Service]
-ExecStartPre=-/usr/sbin/modprobe tdx-guest
 ExecStart=/usr/bin/attestation-agent --config-file /etc/trustiflux/attestation-agent.toml -a unix:///run/confidential-containers/attestation-agent/attestation-agent.sock
 Environment=RUST_LOG=debug
 StandardOutput=journal+console
 StandardError=journal+console
-Restart=always
-RestartSec=5
 Delegate=yes
 KillMode=process
 OOMScoreAdjust=-999
@@ -21,5 +20,3 @@ LimitNOFILE=1048576
 LimitNPROC=infinity
 LimitCORE=infinity
 
-[Install]
-WantedBy=basic.target

--- a/dist/dracut/modules.d/99attestation-agent/module-setup.sh
+++ b/dist/dracut/modules.d/99attestation-agent/module-setup.sh
@@ -12,7 +12,8 @@ install() {
     inst_multiple /usr/bin/attestation-agent
     inst_simple $moddir/attestation-agent.service /usr/lib/systemd/system/attestation-agent.service
     inst_simple $moddir/attestation-agent.toml /etc/trustiflux/attestation-agent.toml
-    systemctl --root "$initdir" enable attestation-agent.service
+    inst_simple $moddir/attestation-agent-platform-detect.service /usr/lib/systemd/system/attestation-agent-platform-detect.service
+    inst_simple $moddir/attestation-agent-platform-detect.sh /usr/bin/attestation-agent-platform-detect.sh
 }
 
 installkernel() {


### PR DESCRIPTION
on non-tdx platforms, eventlog on rtmr is actually not supported. Thus we add an one-shot service to help to modify the eventlog enablement status before AA starts.