### PR TITLE
dracut: remove dependency on sysinit.target

### DIFF
--- a/dist/dracut/modules.d/99attestation-agent/attestation-agent-platform-detect.service
+++ b/dist/dracut/modules.d/99attestation-agent/attestation-agent-platform-detect.service
@@ -2,7 +2,6 @@
 Description=Attestation-Agent Detect Platform Attributes
 DefaultDependencies=no
 ConditionPathExists=/etc/initrd-release
-After=sysinit.target
 
 [Service]
 Type=oneshot

--- a/dist/dracut/modules.d/99attestation-agent/attestation-agent.service
+++ b/dist/dracut/modules.d/99attestation-agent/attestation-agent.service
@@ -3,7 +3,6 @@ Description=Attestation-Agent
 Documentation=https://confidentialcontainers.org
 DefaultDependencies=no
 ConditionPathExists=/etc/initrd-release
-After=sysinit.target
 After=attestation-agent-platform-detect.service
 Before=basic.target
 Requires=attestation-agent-platform-detect.service


### PR DESCRIPTION
The systemd service `attestation-agent-platform-detect.service` and `attestation-agent.service` depend on the `sysinit.target` unit. As descripted in [here](https://people.redhat.com/~iwienand/dracut-web/man/dracut.bootup.7.html). This `sysinit.target` unit may not been triggered before the dracut main loop (a.k.a. `dracut-initqueue.service`), causing [CryptPilot](https://github.com/openanolis/cryptpilot) to occasionally blocks at startup.

In this commit we remove the dependency on `sysinit.target` to make `attestation-agent` to run as early as possible.

Before this commit:
```txt
[    6.862643] integrity: Unable to open file: /etc/keys/x509_ima.der (-2)
[    6.862705] integrity: Unable to open file: /etc/keys/x509_evm.der (-2)
[  OK  ] Started Show Plymouth Boot Screen.
[  OK  ] Reached target Paths.
[  OK  ] Reached target Local Encrypted Volumes.
[  OK  ] Reached target System Initialization.
         Starting Attestation-Agent Detect Platform Attributes...
[  OK  ] Started Forward Password Requests to Plymouth Directory Watch.
[  OK  ] Found device /dev/disk/by-uuid/B52A-C548.
[  OK  ] Started Attestation-Agent Detect Platform Attributes.
[  OK  ] Found device /dev/disk/by-uuid/65b72930-5de1-4002-be1f-2ef68bd3bd4d.
[  OK  ] Started Attestation-Agent.
[  OK  ] Reached target Basic System.
[  OK  ] Started Hardware RNG Entropy Gatherer Daemon.
[   13.863270] attestation-agent[475]: [2025-07-03T06:15:46Z INFO  attestation_agent] Using AA config file: /etc/trustiflux/attestation-agent.toml
[   13.907476] attestation-agent[475]: [2025-07-03T06:15:46Z WARN  attester] No TEE platform detected. Sample Attester will be used.
[   13.915261] attestation-agent[475]: [2025-07-03T06:15:46Z DEBUG ttrpc_aa] Attestation ttRPC service listening on: "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
```

As we can see, attestation-agent is launched after the `sysinit.target`(The line `[  OK  ] Reached target System Initialization.`)

After this commit:
```txt
[    5.809187] integrity: Unable to open file: /etc/keys/x509_ima.der (-2)
[    5.809264] integrity: Unable to open file: /etc/keys/x509_evm.der (-2)
[    7.500488] attestation-agent[223]: [2025-07-03T06:49:02Z INFO  attestation_agent] Using AA config file: /etc/trustiflux/attestation-agent.toml
[    7.503291] attestation-agent[223]: [2025-07-03T06:49:02Z WARN  attester] No TEE platform detected. Sample Attester will be used.
[    7.504889] attestation-agent[223]: [2025-07-03T06:49:02Z DEBUG ttrpc_aa] Attestation ttRPC service listening on: "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
[  OK  ] Started Show Plymouth Boot Screen.
[  OK  ] Found device /dev/disk/by-uuid/B52A-C548.
[  OK  ] Found device /dev/disk/by-uuid/65b72930-5de1-4002-be1f-2ef68bd3bd4d.
[  OK  ] Reached target Local Encrypted Volumes.
[  OK  ] Reached target Paths.
[  OK  ] Started Forward Password Requests to Plymouth Directory Watch.
[  OK  ] Started initrd-wait-network-online.service.
[  OK  ] Reached target Network is Online.
```