### PR TITLE
dracut: fix AA bash to /bin/bash

### DIFF
--- a/dist/dracut/modules.d/99attestation-agent/attestation-agent-platform-detect.service
+++ b/dist/dracut/modules.d/99attestation-agent/attestation-agent-platform-detect.service
@@ -5,5 +5,5 @@ ConditionPathExists=/etc/initrd-release
 
 [Service]
 Type=oneshot
-ExecStart=bash /usr/bin/attestation-agent-platform-detect.sh
+ExecStart=/bin/bash /usr/bin/attestation-agent-platform-detect.sh
 RemainAfterExit=true


### PR DESCRIPTION
Executable path is not absolute, ignoring: bash /usr/bin/attestation-agent-platform-detect.sh attestation-agent-platform-detect.service lacks both ExecStart= and ExecStop= setting. Refusing.