### PR TITLE
kbs_protocol: align e2e test with new KBS config schema

### DIFF
--- a/attestation-agent/kbs_protocol/src/client/rcar_client.rs
+++ b/attestation-agent/kbs_protocol/src/client/rcar_client.rs
@@ -437,6 +437,7 @@ mod test {
         GenericImage, ImageExt,
     };
     use tokio::fs;
+    use tokio::io::AsyncBufReadExt;
 
     use crate::{
         evidence_provider::NativeEvidenceProvider, Error, KbsClientBuilder, KbsClientCapabilities,
@@ -453,18 +454,13 @@ mod test {
 
     #[tokio::test]
     #[serial_test::serial]
-    #[ignore]
     async fn test_client() {
         // prepare test resource
         let tmp = tempfile::tempdir().expect("create tempdir");
         let mut resource_path = PathBuf::new();
         resource_path.push(tmp.path());
-        resource_path.push("default/key");
-        fs::create_dir_all(resource_path.clone())
-            .await
-            .expect("create resource path");
+        resource_path.push("default\\x2Fkey\\x2Ftestfile");
 
-        resource_path.push("testfile");
         fs::write(resource_path.clone(), CONTENT)
             .await
             .expect("write content");
@@ -487,7 +483,7 @@ mod test {
         .with_exposed_port(8085.tcp())
         .with_mount(Mount::bind_mount(
             tmp.path().as_os_str().to_string_lossy(),
-            "/opt/confidential-containers/kbs/repository",
+            "/opt/confidential-containers/trustee/repository",
         ))
         .with_mount(Mount::bind_mount(
             start_kbs_script.into_os_string().to_string_lossy(),
@@ -499,12 +495,44 @@ mod test {
         ))
         .with_mount(Mount::bind_mount(
             policy.into_os_string().to_string_lossy(),
-            "/opa/confidential-containers/kbs/policy.rego",
+            "/opt/confidential-containers/trustee/kbs/resource-policy.rego",
         ))
+        .with_env_var("RUST_LOG", "debug")
         .with_cmd(vec!["/usr/local/bin/start_kbs.sh"])
         .start()
         .await
         .expect("run kbs failed");
+
+        let stdout = kbs.stdout(true);
+        let stderr = kbs.stderr(true);
+        let _stdout_log = tokio::spawn(async move {
+            let mut lines = stdout.lines();
+            loop {
+                match lines.next_line().await {
+                    Ok(Some(line)) => println!("[kbs container stdout] {line}"),
+                    Ok(None) => break,
+                    Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                    Err(e) => {
+                        eprintln!("[kbs container stdout] log stream error: {e}");
+                        break;
+                    }
+                }
+            }
+        });
+        let _stderr_log = tokio::spawn(async move {
+            let mut lines = stderr.lines();
+            loop {
+                match lines.next_line().await {
+                    Ok(Some(line)) => println!("[kbs container stderr] {line}"),
+                    Ok(None) => break,
+                    Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                    Err(e) => {
+                        eprintln!("[kbs container stderr] log stream error: {e}");
+                        break;
+                    }
+                }
+            }
+        });
 
         tokio::time::sleep(Duration::from_secs(10)).await;
         let port = kbs.get_host_port_ipv4(8085).await.expect("get port");

--- a/attestation-agent/kbs_protocol/test/kbs-config.toml
+++ b/attestation-agent/kbs_protocol/test/kbs-config.toml
@@ -5,9 +5,6 @@ sockets = ["0.0.0.0:8085"]
 [attestation_token]
 insecure_key = true
 
-[policy_engine]
-policy_path = "/opa/confidential-containers/kbs/policy.rego"
-
 [attestation_service]
 type = "coco_as_builtin"
 work_dir = "/opt/confidential-containers/attestation-service"
@@ -18,12 +15,14 @@ duration_min = 5
 
 [attestation_service.rvps_config]
 type = "BuiltIn"
-store_type = "LocalFs"
 
 [admin]
 type = "InsecureAllowAll"
 
 [[plugins]]
 name = "resource"
-type = "LocalFs"
-dir_path = "/opt/confidential-containers/kbs/repository"
+type = "kvstorage"
+
+[storage_backend]
+storage_type = "local_fs"
+backends.local_fs.dir_path = "/opt/confidential-containers/trustee"

--- a/attestation-agent/kbs_protocol/test/kbs-config.toml
+++ b/attestation-agent/kbs_protocol/test/kbs-config.toml
@@ -3,7 +3,7 @@ insecure_http = true
 sockets = ["0.0.0.0:8085"]
 
 [attestation_token]
-insecure_key = true
+insecure_header_jwk = true
 
 [attestation_service]
 type = "coco_as_builtin"
@@ -17,11 +17,11 @@ duration_min = 5
 type = "BuiltIn"
 
 [admin]
-type = "InsecureAllowAll"
+authorization_mode = "InsecureAllowAll"
 
 [[plugins]]
 name = "resource"
-type = "kvstorage"
+storage_backend_type = "kvstorage"
 
 [storage_backend]
 storage_type = "local_fs"


### PR DESCRIPTION
## Summary

- The KBS image `ghcr.io/confidential-containers/staged-images/kbs:latest` was updated to a new config schema (`kvstorage` plugin + `[storage_backend]` section, repository/policy rooted at `/opt/confidential-containers/trustee`). Our e2e test in `kbs_protocol` still used the old `LocalFs` plugin layout, so the KBS container exits at startup config validation, leaving the test panicking at `kbs.get_host_port_ipv4(8085)` with `PortNotExposed`. As a workaround, commit `5651725a` marked `test_client` as `#[ignore]`.
- This PR ports the upstream fix ([confidential-containers/guest-components#1400](https://github.com/confidential-containers/guest-components/pull/1400), commit [`4358d1f5`](https://github.com/confidential-containers/guest-components/commit/4358d1f5e257803ee0f35b4c7d9afe5a0725fa0e)):
  - `kbs-config.toml` — switch resource plugin to `kvstorage` + add `[storage_backend]` using `local_fs` under `/opt/confidential-containers/trustee`; drop the now-unsupported `[policy_engine]` section and the obsolete `rvps_config.store_type`.
  - `rcar_client.rs` test — move resource and policy bind-mounts under the new `trustee/` paths, encode the resource path as a single escaped filename (`default\x2Fkey\x2Ftestfile`) to match the `kvstorage` layout, stream container stdout/stderr through `tokio::spawn` so future regressions are diagnosable, and remove `#[ignore]` now that the test passes.

Upstream PR #1400 confirms `test_client` passes on `ubuntu-24.04`, `ubuntu-24.04-arm`, and `ubuntu-24.04-s390x` with these changes.

This also unsticks PR #85 (`initdata-processor: add initdata processor component`), which branched off main before `5651725a` was applied and therefore still runs the broken test in CI.

## Test plan

- [x] `cargo check --tests -p kbs_protocol --features openssl,rust-crypto,all-attesters,kbs,coco_as`
- [ ] CI `attestation-agent basic build and unit tests` (runs `test_client` end-to-end against the latest staged KBS image)