### PR TITLE
image-rs: add image pull benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,6 +957,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cast5"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1040,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1398,6 +1437,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap 4.2.7",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -2623,6 +2698,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3203,6 +3288,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "cfg-if",
+ "criterion",
  "devicemapper",
  "dircpy",
  "filetime",
@@ -4552,6 +4638,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4972,6 +5064,34 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "pnet"
@@ -7079,6 +7199,16 @@ checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/image-rs/Cargo.toml
+++ b/image-rs/Cargo.toml
@@ -71,6 +71,7 @@ anyhow.workspace = true
 
 [dev-dependencies]
 cfg-if.workspace = true
+criterion = "0.5"
 nix = { workspace = true, features = ["user"] }
 ring.workspace = true
 rstest.workspace = true
@@ -187,3 +188,8 @@ kbs = []
 nydus = ["lazy_static", "nydus-api", "nydus-service"]
 
 verity = ["devicemapper"]
+
+[[bench]]
+name = "image-pull"
+harness = false
+test = false

--- a/image-rs/README.md
+++ b/image-rs/README.md
@@ -8,3 +8,73 @@ Container Images Rust Crate
 
 [CCv1 Image Security Design document](docs/ccv1_image_security_design.md)
 
+## Performance Testing
+
+This crate includes benchmark tests to measure image pull throughput and memory consumption.
+We use [cargo bench](https://doc.rust-lang.org/cargo/commands/cargo-bench.html) to test image pull throughput and [heaptrack](https://github.com/KDE/heaptrack) for memory consumption.
+
+### Running Benchmarks
+
+#### Prerequisites
+
+Install heaptrack for memory consumption analysis:
+
+```bash
+sudo apt install heaptrack -y
+```
+
+#### Running the Benchmark
+
+To run the image pull benchmark:
+
+```bash
+heaptrack cargo bench -p image-rs --bench image-pull
+```
+
+The benchmark measures:
+- Image pull time
+- Throughput (MiB per second)
+
+#### Understanding the Results
+
+**Throughput Results**
+
+Detailed performance metrics and visualizations are generated in the `target/criterion/` directory.
+At the same time, a summary is displayed in the terminal:
+
+```
+image-pull/ghcr.io/confidential-containers/test-container:unencrypted
+                        time:   [2.3829 s 2.4001 s 2.4197 s]
+                        thrpt:  [3.5598 MiB/s 3.5889 MiB/s 3.6148 MiB/s]
+                 change:
+                        time:   [−3.7930% −0.9001% +1.3846%] (p = 0.61 > 0.05)
+                        thrpt:  [−1.3657% +0.9083% +3.9425%]
+                        No change in performance detected.
+```
+
+**Memory Consumption Report**
+
+After the benchmark completes, heaptrack will display a command to analyze the memory data:
+
+```
+Heaptrack finished! Now run the following to investigate the data:
+
+  heaptrack --analyze "xxxx/heaptrack.cargo.3133205.zst"
+```
+
+Run the provided command to generate the memory consumption report:
+
+```bash
+heaptrack --analyze "xxxx/heaptrack.cargo.3133205.zst"
+```
+
+The report includes metrics such as:
+
+```
+bytes allocated in total (ignoring deallocations): 51.85MB (328.14MB/s)
+calls to allocation functions: 237333 (1502107/s)
+temporary memory allocations: 89438 (566063/s)
+peak heap memory consumption: 14.17MB
+peak RSS (including heaptrack overhead): 126.19MB
+total memory leaked: 1.14MB
+```

--- a/image-rs/benches/image-pull.rs
+++ b/image-rs/benches/image-pull.rs
@@ -1,0 +1,87 @@
+// Copyright (c) 2025 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use image_rs::image::ImageClient;
+use nix::mount::umount;
+use std::{fs, path::Path, time::Duration};
+
+/// The image URLs to be pulled.
+/// TODO: add more image URLs to be pulled.
+const IMAGE_URLS: [&str; 1] = ["ghcr.io/confidential-containers/test-container:unencrypted"];
+
+fn get_total_file_size(path: &Path) -> u64 {
+    if !path.exists() {
+        return 0;
+    }
+
+    let metadata = fs::symlink_metadata(path).unwrap();
+
+    if metadata.is_file() {
+        return metadata.len();
+    }
+
+    if metadata.is_dir() {
+        let entries = fs::read_dir(path).unwrap();
+        return entries
+            .map(|entry| get_total_file_size(&entry.unwrap().path()))
+            .sum();
+    }
+
+    0
+}
+
+fn pull_image(image_url: &str) -> u64 {
+    let bundle_dir = tempfile::tempdir().unwrap();
+    let bundle_dir_path = bundle_dir.path().to_path_buf();
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let bundle_dir_path_clone = bundle_dir_path.clone();
+    let mut image_client = ImageClient::new(bundle_dir.path().to_path_buf());
+    runtime
+        .block_on(async move {
+            image_client
+                .pull_image(image_url, &bundle_dir_path_clone, &None, &None)
+                .await
+        })
+        .unwrap();
+    let data_dir = bundle_dir_path.join("rootfs");
+    let total_size = get_total_file_size(&data_dir);
+
+    umount(&data_dir).unwrap();
+    drop(bundle_dir);
+    total_size
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("image-pull");
+    group.sample_size(10);
+
+    for image_url in IMAGE_URLS {
+        // Run once to get the data size for throughput calculation
+        let sample_size = pull_image(image_url);
+        group.throughput(Throughput::Bytes(sample_size));
+
+        group.bench_function(image_url, |b| {
+            b.iter_custom(|iters| {
+                let mut total_duration = Duration::new(0, 0);
+
+                for _ in 0..iters {
+                    let start = std::time::Instant::now();
+                    // let resident_before = resident.read().unwrap();
+                    pull_image(image_url);
+                    let elapsed = start.elapsed();
+
+                    total_duration += elapsed;
+                }
+
+                total_duration
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
## 背景

吸收上游 confidential-containers/guest-components 的 image pull 基准测试，便于持续观测 image-rs 拉取性能与内存占用。

- 上游 commit：confidential-containers/guest-components `3cdb4560`（image-rs: add image pull benchmark）

## 改动内容

- 新增 `image-rs/benches/image-pull.rs`：基于 criterion 的拉取耗时 / 吞吐基准。
- `image-rs/Cargo.toml`：新增 dev-dependency `criterion` 与 `[[bench]]` 段（`harness = false`、`test = false`）。
- `image-rs/README.md`：补充 benchmark 运行说明。
- `Cargo.lock`：相应锁定。

## 适配说明（相对上游）

- criterion 固定为 **0.5**（上游用 0.7）。原因：本 fork 的 workspace 把 `clap` 锁在 `~4.2.7`，而 criterion 0.7 要求 `clap >= 4.5`，无法共存。基准仅使用 `criterion_group/criterion_main/Criterion/Throughput` 等稳定 API，版本差异透明。
- `Cargo.lock` 将传递依赖 `half` pin 到 `2.4.1`，以保持 rustc 1.76 的 MSRV。

## 兼容性

- 不新增/修改/删除任何 API。
- 不修改任何现有配置项。
- 不改变默认行为：`[[bench]]` 标记 `test = false`，默认构建/测试不编译此 bench。
- 现有客户端 / 部署不受影响（零运行时影响）。

## 验证

- `cargo bench -p image-rs --bench image-pull --no-run` 编译通过（rustc 1.76）。
- `cargo check -p image-rs` 通过。
