### PR TITLE
CDH: support reading image pull config from kernel cmdline

### DIFF
--- a/confidential-data-hub/example.config.toml
+++ b/confidential-data-hub/example.config.toml
@@ -115,6 +115,9 @@ image_security_policy_uri = "kbs:///default/security-policy/test"
 # e.g. `file:///etc/image-registry-auth.json`.
 #
 # By default this value is not set.
+#
+# Note that if an environment variable `CDH_DEFAULT_IMAGE_AUTHENTICATED_REGISTRY_CREDENTIALS`
+# is set, the value of the environment variable will be used.
 authenticated_registry_credentials_uri = "kbs:///default/credential/test"
 
 # Proxy that will be used to pull image

--- a/confidential-data-hub/hub/src/config.rs
+++ b/confidential-data-hub/hub/src/config.rs
@@ -22,6 +22,9 @@ cfg_if::cfg_if! {
     }
 }
 
+const CDH_DEFAULT_IMAGE_AUTHENTICATED_REGISTRY_CREDENTIALS: &str =
+    "CDH_DEFAULT_IMAGE_AUTHENTICATED_REGISTRY_CREDENTIALS";
+
 #[derive(Clone, Deserialize, Debug, PartialEq)]
 pub struct KbsConfig {
     pub name: String,
@@ -98,6 +101,13 @@ impl CdhConfig {
                 }
             }
         };
+
+        if let std::result::Result::Ok(env) =
+            env::var(CDH_DEFAULT_IMAGE_AUTHENTICATED_REGISTRY_CREDENTIALS)
+        {
+            info!("Read authenticated registry credentials URI from env: {env}");
+            config.image.authenticated_registry_credentials_uri = Some(env);
+        }
 
         config.extend_credentials_from_kernel_cmdline()?;
         Ok(config)
@@ -330,5 +340,49 @@ some_undefined_field = "unknown value"
         let config = CdhConfig::new(Some("/thing".into())).unwrap_err();
         let expected = anyhow!("Config file /thing not found.");
         assert_eq!(format!("{config}"), format!("{expected}"));
+    }
+
+    #[test]
+    fn test_config_auth_override_by_env() {
+        let config = r#"
+[kbc]
+name = "offline_fs_kbc"
+
+[image]
+authenticated_registry_credentials_uri = "kbs:///default/auth/1"
+        "#;
+        let mut file = tempfile::Builder::new()
+            .append(true)
+            .suffix(".toml")
+            .tempfile()
+            .unwrap();
+        file.write_all(config.as_bytes()).unwrap();
+
+        // without env and from config file
+        let config_path = file.path().to_str().unwrap().to_string();
+        let config = CdhConfig::new(Some(config_path.clone())).expect("Must be successful");
+        assert_eq!(
+            config.image.authenticated_registry_credentials_uri,
+            Some("kbs:///default/auth/1".into())
+        );
+
+        // overrided by env
+        env::set_var(
+            "CDH_DEFAULT_IMAGE_AUTHENTICATED_REGISTRY_CREDENTIALS",
+            "file:///test",
+        );
+        let config = CdhConfig::new(Some(config_path.clone())).unwrap();
+        assert_eq!(
+            config.image.authenticated_registry_credentials_uri,
+            Some("file:///test".to_string())
+        );
+        env::remove_var("CDH_DEFAULT_IMAGE_AUTHENTICATED_REGISTRY_CREDENTIALS");
+
+        // no env again
+        let config = CdhConfig::new(Some(config_path)).unwrap();
+        assert_eq!(
+            config.image.authenticated_registry_credentials_uri,
+            Some("kbs:///default/auth/1".into())
+        );
     }
 }

--- a/confidential-data-hub/hub/src/config.rs
+++ b/confidential-data-hub/hub/src/config.rs
@@ -57,7 +57,10 @@ pub struct CdhConfig {
     #[serde(default)]
     pub credentials: Vec<Credential>,
 
-    #[serde(default)]
+    /// Image pull configuration. Note that if `[image]` section is not given,
+    /// the image pull configuration will be read from kernel commandline together
+    /// with default values.
+    #[serde(default = "ImageConfig::from_kernel_cmdline")]
     pub image: ImageConfig,
 
     pub socket: String,
@@ -85,13 +88,13 @@ impl CdhConfig {
                 Self::from_file(&path)?
             }
             None => {
-                info!("No config path specified, use a default config.");
+                info!("No config path specified, use a default config (some parts will read from kernel cmdline).");
                 Self {
                     kbc: KbsConfig::new()?,
                     credentials: Vec::new(),
                     socket: DEFAULT_CDH_SOCKET_ADDR.into(),
                     aa_socket: DEFAULT_AA_SOCKET_ADDR.into(),
-                    image: ImageConfig::default(),
+                    image: ImageConfig::from_kernel_cmdline(),
                 }
             }
         };
@@ -310,7 +313,7 @@ some_undefined_field = "unknown value"
             credentials: Vec::new(),
             socket: DEFAULT_CDH_SOCKET_ADDR.into(),
             aa_socket: DEFAULT_AA_SOCKET_ADDR.into(),
-            image: ImageConfig::default(),
+            image: ImageConfig::from_kernel_cmdline(),
         };
         assert_eq!(config, expected);
 

--- a/image-rs/src/config.rs
+++ b/image-rs/src/config.rs
@@ -3,8 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{anyhow, Result};
+use log::debug;
 use serde::Deserialize;
-use std::fs::File;
+use std::collections::HashMap;
+use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 
 use crate::snapshots::SnapshotType;
@@ -179,6 +181,39 @@ impl Default for ImageConfig {
     }
 }
 
+#[derive(PartialEq, Debug)]
+struct KernelParameterConfigs {
+    https_proxy: Option<String>,
+    no_proxy: Option<String>,
+    authenticated_registry_credentials_uri: Option<String>,
+    image_security_policy_uri: Option<String>,
+    enable_signature_verification: bool,
+}
+
+impl KernelParameterConfigs {
+    fn new(kernel_cmdline: &str) -> Self {
+        let cmdline: HashMap<&str, &str> = kernel_cmdline
+            .split_ascii_whitespace()
+            .filter_map(|s| s.split_once('='))
+            .collect();
+
+        Self {
+            https_proxy: cmdline.get("agent.https_proxy").map(|s| s.to_string()),
+            no_proxy: cmdline.get("agent.no_proxy").map(|s| s.to_string()),
+            authenticated_registry_credentials_uri: cmdline
+                .get("agent.image_registry_auth")
+                .map(|s| s.to_string()),
+            image_security_policy_uri: cmdline
+                .get("agent.image_policy_file")
+                .map(|s| s.to_string()),
+            enable_signature_verification: cmdline
+                .get("agent.enable_signature_verification")
+                .map(|s| s.parse::<bool>().unwrap_or(false))
+                .unwrap_or_default(),
+        }
+    }
+}
+
 impl TryFrom<&Path> for ImageConfig {
     /// Load `ImageConfig` from a configuration file like:
     ///    {
@@ -204,6 +239,48 @@ impl TryFrom<&Path> for ImageConfig {
 }
 
 impl ImageConfig {
+    /// Try read configs from kernel command line, and other items will be set as default.
+    pub fn from_kernel_cmdline() -> Self {
+        let mut res = ImageConfig {
+            work_dir: PathBuf::from(DEFAULT_WORK_DIR.to_string()),
+            #[cfg(feature = "snapshot-overlayfs")]
+            default_snapshot: SnapshotType::Overlay,
+            #[cfg(not(feature = "snapshot-overlayfs"))]
+            default_snapshot: SnapshotType::Unknown,
+            max_concurrent_layer_downloads_per_image: DEFAULT_MAX_CONCURRENT_DOWNLOAD,
+            #[cfg(feature = "nydus")]
+            nydus_config: Some(NydusConfig::default()),
+            #[cfg(not(feature = "nydus"))]
+            nydus_config: None,
+            image_security_policy_uri: None,
+            sigstore_config_uri: None,
+            authenticated_registry_credentials_uri: None,
+            image_pull_proxy: None,
+            skip_proxy_ips: None,
+            extra_root_certificates: Vec::new(),
+
+            #[cfg(feature = "keywrap-native")]
+            kbc: default_kbc(),
+
+            #[cfg(feature = "keywrap-native")]
+            kbs_uri: default_kbs_uri(),
+        };
+
+        if let Ok(kernel_cmdline) = fs::read_to_string("/proc/cmdline") {
+            debug!("Try read image pull parameters from kernel cmdline");
+            let parameters_from_kernel = KernelParameterConfigs::new(&kernel_cmdline);
+            res.image_pull_proxy = parameters_from_kernel.https_proxy;
+            res.skip_proxy_ips = parameters_from_kernel.no_proxy;
+            res.authenticated_registry_credentials_uri =
+                parameters_from_kernel.authenticated_registry_credentials_uri;
+            if parameters_from_kernel.enable_signature_verification {
+                res.image_security_policy_uri = parameters_from_kernel.image_security_policy_uri;
+            }
+        }
+
+        res
+    }
+
     /// Construct an instance of `ImageConfig` with specific work directory.
     pub fn new(image_work_dir: PathBuf) -> Self {
         Self {
@@ -358,8 +435,89 @@ impl Default for FscacheConfig {
 #[cfg(feature = "snapshot-overlayfs")]
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
     use std::io::prelude::*;
+
+    #[rstest]
+    #[case(
+        "BOOT_IMAGE=/boot/vmlinuz-6.2.0-060200-generic root=UUID=f601123 ro vga=792 console=tty0 console=ttyS0,115200n8 agent.https_proxy=http://1.2.3.4:1234",
+        KernelParameterConfigs {
+            https_proxy: Some("http://1.2.3.4:1234".into()),
+            no_proxy: None,
+            authenticated_registry_credentials_uri: None,
+            image_security_policy_uri: None,
+            enable_signature_verification: false
+        }
+    )]
+    #[case("
+        BOOT_IMAGE=/boot/vmlinuz-6.2.0-060200-generic agent.no_proxy=localhost root=UUID=f601123 ro vga=792 console=tty0 console=ttyS0,115200n8 agent.https_proxy=http://1.2.3.4:1234",
+        KernelParameterConfigs {
+            https_proxy: Some("http://1.2.3.4:1234".into()),
+            no_proxy: Some("localhost".into()),
+            authenticated_registry_credentials_uri: None,
+            image_security_policy_uri: None,
+            enable_signature_verification: false
+        }
+    )]
+    #[case("
+        BOOT_IMAGE=/boot/vmlinuz-6.2.0-060200-generic agent.no_proxy=localhost   \n agent.image_registry_auth=kbs:///default/credentials/test root=UUID=f601123 ro vga=792 console=tty0 console=ttyS0,115200n8 agent.https_proxy=http://1.2.3.4:1234",
+        KernelParameterConfigs {
+            https_proxy: Some("http://1.2.3.4:1234".into()),
+            no_proxy: Some("localhost".into()),
+            authenticated_registry_credentials_uri: Some("kbs:///default/credentials/test".into()),
+            image_security_policy_uri: None,
+            enable_signature_verification: false
+        }
+    )]
+    #[case("
+        agent.no_proxy=localhost   \n agent.image_registry_auth=file:///root/.docker/config.json agent.https_proxy=http://1.2.3.4:1234",
+        KernelParameterConfigs {
+            https_proxy: Some("http://1.2.3.4:1234".into()),
+            no_proxy: Some("localhost".into()),
+            authenticated_registry_credentials_uri: Some("file:///root/.docker/config.json".into()),
+            image_security_policy_uri: None,
+            enable_signature_verification: false
+        }
+    )]
+    #[case("
+        BOOT_IMAGE=/boot/vmlinuz-6.2.0-060200-generic agent.no_proxy=localhost agent.image_policy_file=kbs:///default/image-policy/test  \n agent.image_registry_auth=kbs:///a/b/c root=UUID=f601123 ro vga=792 console=tty0 console=ttyS0,115200n8 agent.https_proxy=http://1.2.3.4:1234",
+        KernelParameterConfigs {
+            https_proxy: Some("http://1.2.3.4:1234".into()),
+            no_proxy: Some("localhost".into()),
+            authenticated_registry_credentials_uri: Some("kbs:///a/b/c".into()),
+            image_security_policy_uri: Some("kbs:///default/image-policy/test".into()),
+            enable_signature_verification: false
+        }
+    )]
+    #[case("
+        BOOT_IMAGE=/boot/vmlinuz-6.2.0-060200-generic agent.no_proxy=localhost agent.image_policy_file=file:///etc/image-policy.json  \n agent.image_registry_auth=kbs:///a/b/c root=UUID=f601123 ro vga=792 console=tty0 console=ttyS0,115200n8 agent.https_proxy=http://1.2.3.4:1234",
+        KernelParameterConfigs {
+            https_proxy: Some("http://1.2.3.4:1234".into()),
+            no_proxy: Some("localhost".into()),
+            authenticated_registry_credentials_uri: Some("kbs:///a/b/c".into()),
+            image_security_policy_uri: Some("file:///etc/image-policy.json".into()),
+            enable_signature_verification: false
+        }
+    )]
+    #[case("
+        agent.enable_signature_verification=true agent.no_proxy=localhost agent.image_policy_file=file:///etc/image-policy.json  \n agent.image_registry_auth=kbs:///a/b/c agent.https_proxy=http://1.2.3.4:1234",
+        KernelParameterConfigs {
+            https_proxy: Some("http://1.2.3.4:1234".into()),
+            no_proxy: Some("localhost".into()),
+            authenticated_registry_credentials_uri: Some("kbs:///a/b/c".into()),
+            image_security_policy_uri: Some("file:///etc/image-policy.json".into()),
+            enable_signature_verification: true
+        }
+    )]
+    fn test_parse_kernel_parameter(
+        #[case] kernel_parameter: &str,
+        #[case] expected: KernelParameterConfigs,
+    ) {
+        let config = KernelParameterConfigs::new(kernel_parameter);
+        assert_eq!(config, expected);
+    }
 
     #[test]
     fn test_image_config() {


### PR DESCRIPTION
## 背景

吸收上游 confidential-containers/guest-components 的「从 kernel cmdline 读取镜像拉取配置」能力，便于 kata-agent 等场景在无配置文件时通过内核命令行下发参数。

- 上游 commits：`b785f051`（image-rs: parse config from kernel cmdline）、`11563f6c`（CDH: read kernel cmdline parameters）、`9d3d6c99`（CDH: read auth URI from env）
- **不含** `15a42d67`（该 commit 改默认 work_dir 路径，属行为变更，不在本 PR 范围）

## 改动内容

- `image-rs/src/config.rs`：新增 `ImageConfig::from_kernel_cmdline()` 与 `KernelParameterConfigs`，从 `/proc/cmdline` 读取 `agent.https_proxy`/`agent.no_proxy`/`agent.image_registry_auth`/`agent.image_policy_file`/`agent.enable_signature_verification`。
- `confidential-data-hub/hub/src/config.rs`：无配置文件时 fallback 走 `from_kernel_cmdline()` 而非 `default()`；支持从环境变量读取 authenticated registry credentials URI。
- `confidential-data-hub/example.config.toml`：注释更新。

## 适配说明（相对上游）

- 冲突解决时保留本 fork 特有的 `aa_socket` 字段。
- **移除了上游 `from_kernel_cmdline` 中对 `registry_configuration_uri` 字段的设置**：本 fork 的 `ImageConfig` 不含该字段（新增该字段属更大范围的改动，另行评估）。其余 kernel cmdline 字段全部保留。

## 兼容性

- 不新增/修改/删除任何对外 API。
- 不修改现有配置项；仅在「未指定配置文件」时把默认来源从 `default()` 增强为「kernel cmdline + 默认值」。
- 默认行为：当 `/proc/cmdline` 不含相关参数时，等价于旧默认值，行为不变。
- 现有部署不受影响。

## 验证

- `cargo check -p confidential-data-hub` 通过。
- `cargo test -p confidential-data-hub config::` —— 6 个 config 测试全部通过。
