### PR TITLE
fix(attester): build evidence_getter under minimal feature sets

### DIFF
--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -104,4 +104,4 @@ se-attester = ["pv"]
 system-attester = ["nix/feature", "pnet", "udev"]
 tpm-attester = ["openssl", "rsa", "num-traits", "tss-esapi"]
 
-bin = ["tokio/rt", "tokio/macros", "clap"]
+bin = ["tokio/rt", "tokio/rt-multi-thread", "tokio/macros", "clap"]


### PR DESCRIPTION
## Problem

The `evidence_getter` binary uses `#[tokio::main]`, which defaults to the **multi-thread** runtime and therefore requires `tokio/rt-multi-thread`. The `bin` feature only enabled `tokio/rt`, so building the standalone evidence tool for a single TEE — e.g.:

```
cargo build --no-default-features --features bin,snp-attester --bin evidence_getter
```

fails to compile with:

```
error: The default runtime flavor is `multi_thread`, but the `rt-multi-thread` feature is disabled.
  --> attestation-agent/attester/src/bin/evidence_getter.rs:26:1
   |
26 | #[tokio::main]
```

This blocks using `evidence_getter` to produce SEV-SNP (or any single-TEE) evidence without pulling in the full default attester set.

## Fix

Add `tokio/rt-multi-thread` to the `bin` feature.

## Validation

Built `evidence_getter` with `--no-default-features --features bin,snp-attester` and used it to produce a real **SEV-SNP** evidence on an **AMD EPYC 9T25 (Turin)** SNP guest.