### PR TITLE
feat(attester): add pure-Go attester library (attester-go)

### DIFF
--- a/attestation-agent/attester-go/README.md
+++ b/attestation-agent/attester-go/README.md
@@ -1,0 +1,131 @@
+# attester-go
+
+A pure-Go re-implementation of the `attester` crate
+(`attestation-agent/attester`). It collects hardware attestation evidence from a
+confidential guest and produces evidence whose **JSON representation is
+byte-compatible with the Rust attester**, so the evidence can be verified by an
+unmodified Trustee `attestation-service`.
+
+The motivation is to let Go programs collect TEE evidence **without cgo and
+without any external shared library** (in particular without `libtdx_attest.so`
+/ DCAP). Every platform is driven through native kernel interfaces (ConfigFS
+TSM, ioctl on `/dev/tdx_guest`, `/dev/sev-guest`, `/dev/csv-guest`, and vsock).
+
+## Supported platforms
+
+| Tee | Mechanism | External `.so` |
+|-----|-----------|----------------|
+| `sample` | software measurement register + event log | none |
+| `tdx` | ConfigFS TSM **or** `GET_REPORT0` + QGS over vsock / `GET_QUOTE` TDVMCALL ioctl | none |
+| `snp` | `/dev/sev-guest` `SNP_GET_EXT_REPORT` ioctl | none |
+| `csv` | `/dev/csv-guest` `CSV_GET_REPORT` ioctl (SM3) | none |
+| TDX GPU evidence | NVIDIA NVML (optional, `-tags gpu`) | `libnvidia-ml` via `dlopen` |
+
+All TDX quote paths present in the Rust attester are implemented:
+
+1. **ConfigFS TSM** (`/sys/kernel/config/tsm/report`) — primary, used when available.
+2. **QGS over vsock** — used when `/etc/tdx-attest.conf` configures a port.
+3. **`TDX_CMD_GET_QUOTE` TDVMCALL ioctl** — fallback (what `libtdx_attest`
+   does internally, reimplemented here without the library).
+
+`GET_REPORT0` (for `BindInitData` / `GetRuntimeMeasurement`) and RTMR extension
+(sysfs + `TDX_CMD_EXTEND_RTMR` ioctl) are also implemented natively.
+
+## Package layout
+
+```
+attester-go/
+├── attester.go          # facade: New() / DetectTeeType() + re-exported API
+├── api/                 # Attester interface + value types (leaf, no platform deps)
+├── internal/            # implementation details
+│   ├── ioctl/           #   Linux _IOC encoding + ioctl wrapper
+│   ├── eventlog/        #   CCEL/AAEL event-log reader
+│   ├── tsm/             #   ConfigFS TSM_REPORT
+│   ├── sm3/             #   self-contained SM3 (for CSV)
+│   └── util/            #   Pad / FileExists
+├── platform/            # one package per TEE
+│   ├── sample/
+│   ├── tdx/             #   tdx.go / qgs.go / report.go / gpu*.go
+│   ├── snp/
+│   └── csv/
+└── cmd/evidence_getter/
+```
+
+Platform packages import `api` (the interface they implement); the top-level
+`attester` package imports `api` + the platform packages and wires them
+together — so there is no import cycle.
+
+## Build
+
+Default build is pure Go with **no cgo** and **no external library**:
+
+```sh
+CGO_ENABLED=0 go build ./...
+```
+
+The resulting binary is fully static and starts on any host — a platform whose
+device node is absent simply is not detected. To enable NVIDIA GPU evidence:
+
+```sh
+CGO_ENABLED=1 go build -tags gpu ./...
+```
+
+`-tags gpu` pulls in `github.com/NVIDIA/go-nvml`, which `dlopen`s
+`libnvidia-ml` at runtime, so the binary still starts on machines without an
+NVIDIA driver (GPU evidence is simply skipped).
+
+## Library usage
+
+```go
+import attester "github.com/confidential-containers/guest-components/attestation-agent/attester-go"
+
+tee := attester.DetectTeeType()          // e.g. attester.TeeTdx
+att, _ := attester.New(tee)
+
+reportData := make([]byte, 64)           // nonce / user data
+evidence, err := att.GetEvidence(reportData) // evidence is compact JSON ([]byte)
+```
+
+The `Attester` interface mirrors the Rust trait: `GetEvidence`,
+`ExtendRuntimeMeasurement`, `BindInitData`, `GetRuntimeMeasurement`,
+`PcrToCcmr`, `CcelHashAlgorithm`.
+
+## evidence_getter
+
+A small CLI mirroring the Rust `evidence_getter` binary:
+
+```sh
+go build -o evidence_getter ./cmd/evidence_getter
+
+./evidence_getter detect                 # print detected TEE
+./evidence_getter commandline <data>     # get evidence, report_data=<data>
+./evidence_getter stdio                  # report_data from stdin
+./evidence_getter file <path>            # report_data from a file
+./evidence_getter measurement <pcr>      # print a runtime measurement register
+./evidence_getter -tee tdx commandline x # force a TEE type
+```
+
+## Evidence-format compatibility notes
+
+The evidence JSON must match `serde_json`'s output of the Rust structs
+byte-for-byte:
+
+- Fixed-size `[u8; N]` fields are rendered as JSON **number arrays**
+  (`[N]byte` in Go, never `[]byte`, which would base64-encode).
+- `Vec<u8>` fields that must render as number arrays (SNP `CertTableEntry.data`,
+  CSV `serial_number`) use a custom marshaler.
+- Newtype wrappers (`GuestPolicy`, `PlatformInfo`, `Usage`, …) render as bare
+  numbers.
+- SNP `cert_type` renders as a bare string (`"VCEK"`) or `{"OTHER":"<uuid>"}`.
+- `Option` fields keep the exact `null` / omitted behaviour of the Rust
+  `#[serde(skip_serializing_if)]` annotations.
+
+## Testing status
+
+- **TDX**: validated end-to-end on real Intel TDX hardware (quote generation via
+  the `GET_QUOTE` TDVMCALL ioctl path, report_data and RTMRs verified to be
+  embedded in the produced quote; runtime measurements via `GET_REPORT0`).
+- **Sample**: covered by unit tests.
+- **SNP / CSV**: struct sizes and JSON byte-format are locked by unit tests; the
+  ioctl collection paths follow the `sev` (4.0.0) and `csv-rs` ABIs but have not
+  been exercised on real SNP/CSV hardware.

--- a/attestation-agent/attester-go/api/api.go
+++ b/attestation-agent/attester-go/api/api.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package api defines the platform-agnostic attester contract: the Attester
+// interface and the small value types it exchanges. It is a leaf package (it
+// imports nothing from the platform implementations), which lets every platform
+// package depend on it without creating an import cycle with the top-level
+// factory in package attester.
+package api
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// Tee identifies the confidential computing platform. The string values match
+// kbs_types::Tee so they can be surfaced through the AttestationAgent
+// GetTeeType RPC unchanged.
+type Tee string
+
+const (
+	TeeSample Tee = "sample"
+	TeeTdx    Tee = "tdx"
+	TeeSnp    Tee = "snp"
+	TeeCsv    Tee = "csv"
+)
+
+// TeeEvidence is the platform specific evidence, ready to be JSON-serialized.
+// It mirrors the Rust `TeeEvidence = serde_json::Value`: GetEvidence returns the
+// already-marshaled, compact JSON so it matches serde_json byte-for-byte.
+type TeeEvidence = json.RawMessage
+
+// InitDataResult is the outcome of BindInitData.
+type InitDataResult int
+
+const (
+	// InitDataOk means the init-data digest was bound / matches.
+	InitDataOk InitDataResult = iota
+	// InitDataUnsupported means the platform does not support init data.
+	InitDataUnsupported
+)
+
+// HashAlgorithm identifies the digest algorithm used by a platform's runtime
+// measurement / event log.
+type HashAlgorithm string
+
+const (
+	HashSha256 HashAlgorithm = "sha256"
+	HashSha384 HashAlgorithm = "sha384"
+	HashSm3    HashAlgorithm = "sm3"
+)
+
+// ErrUnimplemented is returned by optional Attester methods that a given
+// platform does not support, matching the Rust trait default behaviour.
+var ErrUnimplemented = errors.New("attester: unimplemented")
+
+// Attester is the platform-agnostic interface implemented by every TEE
+// attester. It mirrors the Rust `Attester` trait.
+type Attester interface {
+	// GetEvidence calls the hardware to produce evidence. reportData is bound
+	// into the evidence (as user data / nonce) to defeat replay; it is padded
+	// or truncated to the platform's fixed report-data size.
+	GetEvidence(reportData []byte) (TeeEvidence, error)
+
+	// ExtendRuntimeMeasurement extends a TEE dynamic measurement register with
+	// eventDigest, enabling runtime measurement of data.
+	ExtendRuntimeMeasurement(eventDigest []byte, registerIndex uint64) error
+
+	// BindInitData checks that the platform's init-data field matches the given
+	// digest.
+	BindInitData(initDataDigest []byte) (InitDataResult, error)
+
+	// GetRuntimeMeasurement returns the value of the runtime measurement
+	// register mapped from the given PCR index.
+	GetRuntimeMeasurement(pcrIndex uint64) ([]byte, error)
+
+	// PcrToCcmr maps a TPM PCR index to the platform's CC measurement register.
+	PcrToCcmr(pcrIndex uint64) uint64
+
+	// CcelHashAlgorithm returns the hash algorithm used by the platform CCEL.
+	CcelHashAlgorithm() HashAlgorithm
+}
+
+// Base provides the Rust-trait default implementations so concrete attesters
+// only override what they support. Embed it by value.
+type Base struct{}
+
+func (Base) ExtendRuntimeMeasurement(_ []byte, _ uint64) error {
+	return ErrUnimplemented
+}
+
+func (Base) BindInitData(_ []byte) (InitDataResult, error) {
+	return InitDataUnsupported, nil
+}
+
+func (Base) GetRuntimeMeasurement(_ uint64) ([]byte, error) {
+	return nil, ErrUnimplemented
+}
+
+func (Base) PcrToCcmr(_ uint64) uint64 {
+	panic("attester: PcrToCcmr unimplemented")
+}
+
+func (Base) CcelHashAlgorithm() HashAlgorithm {
+	panic("attester: CcelHashAlgorithm unimplemented")
+}

--- a/attestation-agent/attester-go/attester.go
+++ b/attestation-agent/attester-go/attester.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package attester is a pure-Go re-implementation of the guest-components
+// `attester` crate (attestation-agent/attester). It collects hardware
+// attestation evidence from a confidential guest and produces evidence whose
+// JSON representation is byte-compatible with the Rust attester, so it can be
+// verified by an unmodified Trustee attestation-service.
+//
+// Supported TEE platforms: Sample, Intel TDX (+ optional NVIDIA GPU evidence),
+// AMD SEV-SNP and Hygon CSV.
+//
+// The contract (interface and value types) lives in package api; each platform
+// is implemented in its own package under platform/. This file is a thin facade
+// that re-exports the public API and provides the New / DetectTeeType factory.
+//
+// Unlike the Rust crate, all platforms are accessed through native kernel
+// interfaces (ConfigFS TSM, ioctl on /dev/tdx_guest, /dev/sev-guest,
+// /dev/csv-guest, vsock), so the default build has no cgo and no external
+// shared-library dependency. NVIDIA GPU evidence is the only optional native
+// dependency and is gated behind the `gpu` build tag.
+package attester
+
+import (
+	"errors"
+
+	"github.com/confidential-containers/guest-components/attestation-agent/attester-go/api"
+	"github.com/confidential-containers/guest-components/attestation-agent/attester-go/platform/csv"
+	"github.com/confidential-containers/guest-components/attestation-agent/attester-go/platform/sample"
+	"github.com/confidential-containers/guest-components/attestation-agent/attester-go/platform/snp"
+	"github.com/confidential-containers/guest-components/attestation-agent/attester-go/platform/tdx"
+)
+
+// Re-exported API types (see package api).
+type (
+	Attester       = api.Attester
+	Tee            = api.Tee
+	TeeEvidence    = api.TeeEvidence
+	InitDataResult = api.InitDataResult
+	HashAlgorithm  = api.HashAlgorithm
+)
+
+// Re-exported API constants.
+const (
+	TeeSample = api.TeeSample
+	TeeTdx    = api.TeeTdx
+	TeeSnp    = api.TeeSnp
+	TeeCsv    = api.TeeCsv
+
+	InitDataOk          = api.InitDataOk
+	InitDataUnsupported = api.InitDataUnsupported
+
+	HashSha256 = api.HashSha256
+	HashSha384 = api.HashSha384
+	HashSm3    = api.HashSm3
+)
+
+// ErrUnimplemented is returned by unsupported optional Attester methods.
+var ErrUnimplemented = api.ErrUnimplemented
+
+// New returns the Attester for the given Tee, mirroring the Rust
+// `TryFrom<Tee> for BoxedAttester`.
+func New(tee Tee) (Attester, error) {
+	switch tee {
+	case TeeSample:
+		return sample.New(), nil
+	case TeeTdx:
+		return tdx.New(), nil
+	case TeeSnp:
+		return snp.New(), nil
+	case TeeCsv:
+		return csv.New(), nil
+	default:
+		return nil, errors.New("attester: TEE is not supported: " + string(tee))
+	}
+}
+
+// DetectTeeType detects which TEE platform the current environment is running
+// on, falling back to Sample. Order matches the Rust detect_tee_type.
+func DetectTeeType() Tee {
+	switch {
+	case tdx.DetectPlatform():
+		return TeeTdx
+	case snp.DetectPlatform():
+		return TeeSnp
+	case csv.DetectPlatform():
+		return TeeCsv
+	default:
+		return TeeSample
+	}
+}

--- a/attestation-agent/attester-go/attester_test.go
+++ b/attestation-agent/attester-go/attester_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package attester
+
+import "testing"
+
+func TestNewAndDetect(t *testing.T) {
+	for _, tee := range []Tee{TeeSample, TeeTdx, TeeSnp, TeeCsv} {
+		if _, err := New(tee); err != nil {
+			t.Errorf("New(%s) error: %v", tee, err)
+		}
+	}
+	if _, err := New("bogus"); err == nil {
+		t.Error("New(bogus) should fail")
+	}
+	_ = DetectTeeType() // host-dependent; just ensure it runs
+}

--- a/attestation-agent/attester-go/cmd/evidence_getter/main.go
+++ b/attestation-agent/attester-go/cmd/evidence_getter/main.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Command evidence_getter is the Go counterpart of the Rust `evidence_getter`
+// binary: it detects the TEE, collects evidence for a 64-byte report data and
+// prints the evidence JSON to stdout.
+//
+// Usage:
+//
+//	evidence_getter stdio                # read 64 bytes of report data from stdin
+//	evidence_getter commandline <data>   # use <data> (truncated/padded to 64B)
+//	evidence_getter file <path>          # read report data from a file
+//	evidence_getter detect               # just print the detected TEE type
+//
+// An optional -tee flag forces a specific attester (sample|tdx|snp|csv).
+package main
+
+import (
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
+	attester "github.com/confidential-containers/guest-components/attestation-agent/attester-go"
+)
+
+func main() {
+	teeFlag := flag.String("tee", "", "force TEE type (sample|tdx|snp|csv); default: auto-detect")
+	flag.Parse()
+	args := flag.Args()
+
+	tee := attester.DetectTeeType()
+	if *teeFlag != "" {
+		tee = attester.Tee(*teeFlag)
+	}
+
+	if len(args) > 0 && args[0] == "detect" {
+		fmt.Println(tee)
+		return
+	}
+
+	// measurement <pcrIndex>: exercise the GET_REPORT0 / runtime-measurement path.
+	if len(args) >= 2 && args[0] == "measurement" {
+		att, err := attester.New(tee)
+		if err != nil {
+			fatal("create attester: %v", err)
+		}
+		idx, err := strconv.ParseUint(args[1], 10, 64)
+		if err != nil {
+			fatal("bad pcr index: %v", err)
+		}
+		m, err := att.GetRuntimeMeasurement(idx)
+		if err != nil {
+			fatal("get runtime measurement: %v", err)
+		}
+		fmt.Println(hex.EncodeToString(m))
+		return
+	}
+
+	reportData := make([]byte, 64)
+	if len(args) > 0 {
+		switch args[0] {
+		case "stdio":
+			buf, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				fatal("read stdin: %v", err)
+			}
+			copyReport(reportData, buf)
+		case "commandline":
+			if len(args) < 2 {
+				fatal("commandline requires <data>")
+			}
+			copyReport(reportData, []byte(args[1]))
+		case "file":
+			if len(args) < 2 {
+				fatal("file requires <path>")
+			}
+			buf, err := os.ReadFile(args[1])
+			if err != nil {
+				fatal("read file: %v", err)
+			}
+			copyReport(reportData, buf)
+		default:
+			fatal("unknown subcommand %q", args[0])
+		}
+	}
+
+	att, err := attester.New(tee)
+	if err != nil {
+		fatal("create attester: %v", err)
+	}
+	evidence, err := att.GetEvidence(reportData)
+	if err != nil {
+		fatal("get evidence: %v", err)
+	}
+	fmt.Println(string(evidence))
+}
+
+func copyReport(dst, src []byte) {
+	n := len(src)
+	if n > 64 {
+		n = 64
+	}
+	copy(dst[:n], src[:n])
+}
+
+func fatal(format string, a ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", a...)
+	os.Exit(1)
+}

--- a/attestation-agent/attester-go/go.mod
+++ b/attestation-agent/attester-go/go.mod
@@ -1,0 +1,8 @@
+module github.com/confidential-containers/guest-components/attestation-agent/attester-go
+
+go 1.21
+
+require (
+	github.com/NVIDIA/go-nvml v0.13.0-1
+	golang.org/x/sys v0.20.0
+)

--- a/attestation-agent/attester-go/go.sum
+++ b/attestation-agent/attester-go/go.sum
@@ -1,0 +1,4 @@
+github.com/NVIDIA/go-nvml v0.13.0-1 h1:OLX8Jq3dONuPOQPC7rndB6+iDmDakw0XTYgzMxObkEw=
+github.com/NVIDIA/go-nvml v0.13.0-1/go.mod h1:+KNA7c7gIBH7SKSJ1ntlwkfN80zdx8ovl4hrK3LmPt4=
+golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
+golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/attestation-agent/attester-go/internal/eventlog/eventlog.go
+++ b/attestation-agent/attester-go/internal/eventlog/eventlog.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2024 Microsoft Corporation
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package eventlog reads the confidential-computing event log (CCEL and/or
+// AAEL), mirroring the Rust attester utils::read_eventlog.
+package eventlog
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"os"
+)
+
+// elHeader is a fixed event log header prepended before an AAEL log when no
+// CCEL is present. Copied verbatim from utils::EL_HEADER.
+var elHeader = [73]byte{
+	0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x0C, 0x00, 0x30, 0x00,
+	0x12, 0x00, 0x20, 0x00, 0x0B, 0x00, 0x20, 0x00, 0x00,
+}
+
+// elEndFlag is appended after the event log. Copied from utils::EL_END_FLAG.
+var elEndFlag = [8]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}
+
+const (
+	defaultAAELPath = "/run/attestation-agent/eventlog"
+	ccelPath        = "/sys/firmware/acpi/tables/data/CCEL"
+)
+
+// trimCcel trims trailing zero padding from a raw CCEL blob, mirroring
+// utils::trim_ccel.
+func trimCcel(ccel []byte) ([]byte, error) {
+	ccelLen := len(ccel)
+	index := 4
+	if ccelLen < index+4 {
+		return nil, errors.New("invalid ccel: not enough length")
+	}
+	eventTypeNum := binary.LittleEndian.Uint32(ccel[index : index+4])
+	index += 4
+	index += 20
+
+	// if it is EV_NO_ACTION
+	if eventTypeNum == 0x3 {
+		if ccelLen < index+4 {
+			return nil, errors.New("invalid ccel: not enough length")
+		}
+		eventDataSize := binary.LittleEndian.Uint32(ccel[index : index+4])
+		index += 4
+		index += int(eventDataSize)
+	}
+
+	for {
+		if ccelLen < index+8 {
+			return nil, errors.New("invalid ccel: no end flag")
+		}
+		stopFlag := binary.LittleEndian.Uint64(ccel[index : index+8])
+		if stopFlag == 0xFFFFFFFFFFFFFFFF || stopFlag == 0x0000000000000000 {
+			return ccel[:index], nil
+		}
+
+		// skip target mr, event type
+		index += 4 + 4
+		if ccelLen < index+4 {
+			return nil, errors.New("invalid ccel: no digest length")
+		}
+		digestsLength := binary.LittleEndian.Uint32(ccel[index : index+4])
+		index += 4
+
+		for i := uint32(0); i < digestsLength; i++ {
+			if ccelLen < index+2 {
+				return nil, errors.New("invalid ccel: no digest algorithm")
+			}
+			digestType := binary.LittleEndian.Uint16(ccel[index : index+2])
+			index += 2
+			var digestLen int
+			switch digestType {
+			case 0xb, 0x12:
+				digestLen = 0x20
+			case 0xc:
+				digestLen = 0x30
+			case 0xd:
+				digestLen = 0x40
+			default:
+				return nil, errors.New("invalid ccel: unsupported digest algorithm")
+			}
+			index += digestLen
+		}
+
+		if ccelLen < index+4 {
+			return nil, errors.New("invalid ccel: no event data size")
+		}
+		eventDataSize := binary.LittleEndian.Uint32(ccel[index : index+4])
+		index += 4
+		index += int(eventDataSize)
+	}
+}
+
+// Read reads the CC event log (CCEL and/or AAEL) and returns it as a base64
+// (standard) string, or nil if there is no event log.
+func Read() (*string, error) {
+	aaelPath := os.Getenv("AAEL_PATH")
+	if aaelPath == "" {
+		aaelPath = defaultAAELPath
+	}
+
+	var log []byte
+	if _, err := os.Stat(ccelPath); err == nil {
+		raw, err := os.ReadFile(ccelPath)
+		if err != nil {
+			return nil, err
+		}
+		trimmed, err := trimCcel(raw)
+		if err != nil {
+			return nil, err
+		}
+		log = trimmed
+	}
+
+	if _, err := os.Stat(aaelPath); err == nil {
+		if len(log) == 0 {
+			log = append(log, elHeader[:]...)
+		}
+		raw, err := os.ReadFile(aaelPath)
+		if err != nil {
+			return nil, err
+		}
+		log = append(log, raw...)
+	}
+
+	if len(log) == 0 {
+		return nil, nil
+	}
+
+	log = append(log, elEndFlag[:]...)
+	s := base64.StdEncoding.EncodeToString(log)
+	return &s, nil
+}

--- a/attestation-agent/attester-go/internal/ioctl/ioctl.go
+++ b/attestation-agent/attester-go/internal/ioctl/ioctl.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package ioctl provides the Linux _IOC request-number encoding and a small
+// ioctl syscall wrapper.
+package ioctl
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// Linux ioctl _IOC encoding (asm-generic, valid on x86_64/aarch64).
+const (
+	nrBits   = 8
+	typeBits = 8
+	sizeBits = 14
+
+	nrShift   = 0
+	typeShift = nrShift + nrBits
+	sizeShift = typeShift + typeBits
+	dirShift  = sizeShift + sizeBits
+
+	dirNone  = 0
+	dirWrite = 1
+	dirRead  = 2
+)
+
+func code(dir, typ, nr, size uintptr) uintptr {
+	return (dir << dirShift) | (typ << typeShift) | (nr << nrShift) | (size << sizeShift)
+}
+
+// IOW builds a _IOW(type, nr, size) request number.
+func IOW(typ, nr, size uintptr) uintptr { return code(dirWrite, typ, nr, size) }
+
+// IOR builds a _IOR(type, nr, size) request number.
+func IOR(typ, nr, size uintptr) uintptr { return code(dirRead, typ, nr, size) }
+
+// IOWR builds a _IOWR(type, nr, size) request number.
+func IOWR(typ, nr, size uintptr) uintptr { return code(dirWrite|dirRead, typ, nr, size) }
+
+// Do issues an ioctl on fd with the given request and a pointer argument.
+func Do(fd int, request uintptr, arg unsafe.Pointer) error {
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), request, uintptr(arg))
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}

--- a/attestation-agent/attester-go/internal/sm3/sm3.go
+++ b/attestation-agent/attester-go/internal/sm3/sm3.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package sm3 implements the SM3 (GB/T 32905-2016) hash, so the CSV attester
+// has no external crypto dependency.
+package sm3
+
+import "encoding/binary"
+
+// Sum computes the SM3 256-bit digest of data.
+func Sum(data []byte) [32]byte {
+	iv := [8]uint32{
+		0x7380166f, 0x4914b2b9, 0x172442d7, 0xda8a0600,
+		0xa96f30bc, 0x163138aa, 0xe38dee4d, 0xb0fb0e4e,
+	}
+
+	// padding
+	msgLen := uint64(len(data)) * 8
+	msg := make([]byte, len(data))
+	copy(msg, data)
+	msg = append(msg, 0x80)
+	for len(msg)%64 != 56 {
+		msg = append(msg, 0x00)
+	}
+	var lenBuf [8]byte
+	binary.BigEndian.PutUint64(lenBuf[:], msgLen)
+	msg = append(msg, lenBuf[:]...)
+
+	ff0 := func(x, y, z uint32) uint32 { return x ^ y ^ z }
+	ff1 := func(x, y, z uint32) uint32 { return (x & y) | (x & z) | (y & z) }
+	gg0 := func(x, y, z uint32) uint32 { return x ^ y ^ z }
+	gg1 := func(x, y, z uint32) uint32 { return (x & y) | (^x & z) }
+	rotl := func(x uint32, n uint) uint32 { return (x << n) | (x >> (32 - n)) }
+	p0 := func(x uint32) uint32 { return x ^ rotl(x, 9) ^ rotl(x, 17) }
+	p1 := func(x uint32) uint32 { return x ^ rotl(x, 15) ^ rotl(x, 23) }
+
+	v := iv
+	for b := 0; b < len(msg); b += 64 {
+		block := msg[b : b+64]
+		var w [68]uint32
+		for i := 0; i < 16; i++ {
+			w[i] = binary.BigEndian.Uint32(block[i*4:])
+		}
+		for i := 16; i < 68; i++ {
+			w[i] = p1(w[i-16]^w[i-9]^rotl(w[i-3], 15)) ^ rotl(w[i-13], 7) ^ w[i-6]
+		}
+		var w1 [64]uint32
+		for i := 0; i < 64; i++ {
+			w1[i] = w[i] ^ w[i+4]
+		}
+
+		a, bb, c, d := v[0], v[1], v[2], v[3]
+		e, f, g, h := v[4], v[5], v[6], v[7]
+		for j := 0; j < 64; j++ {
+			var tj uint32
+			if j < 16 {
+				tj = 0x79cc4519
+			} else {
+				tj = 0x7a879d8a
+			}
+			ss1 := rotl(rotl(a, 12)+e+rotl(tj, uint(j)%32), 7)
+			ss2 := ss1 ^ rotl(a, 12)
+			var tt1, tt2 uint32
+			if j < 16 {
+				tt1 = ff0(a, bb, c) + d + ss2 + w1[j]
+				tt2 = gg0(e, f, g) + h + ss1 + w[j]
+			} else {
+				tt1 = ff1(a, bb, c) + d + ss2 + w1[j]
+				tt2 = gg1(e, f, g) + h + ss1 + w[j]
+			}
+			d = c
+			c = rotl(bb, 9)
+			bb = a
+			a = tt1
+			h = g
+			g = rotl(f, 19)
+			f = e
+			e = p0(tt2)
+		}
+		v[0] ^= a
+		v[1] ^= bb
+		v[2] ^= c
+		v[3] ^= d
+		v[4] ^= e
+		v[5] ^= f
+		v[6] ^= g
+		v[7] ^= h
+	}
+
+	var out [32]byte
+	for i := 0; i < 8; i++ {
+		binary.BigEndian.PutUint32(out[i*4:], v[i])
+	}
+	return out
+}

--- a/attestation-agent/attester-go/internal/sm3/sm3_test.go
+++ b/attestation-agent/attester-go/internal/sm3/sm3_test.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package sm3
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func TestSum(t *testing.T) {
+	got := Sum([]byte("abc"))
+	want := "66c7f0f462eeedd9d1f2d46bdc10e4e24167c4875cf2f7a2297da02b8f4ba8e0"
+	if hex.EncodeToString(got[:]) != want {
+		t.Fatalf("SM3(abc) = %x, want %s", got, want)
+	}
+}

--- a/attestation-agent/attester-go/internal/tsm/tsm.go
+++ b/attestation-agent/attester-go/internal/tsm/tsm.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2024 Intel Corporation
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package tsm drives the ConfigFS TSM_REPORT interface, mirroring the Rust
+// attester tsm_report module.
+package tsm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const basePath = "/sys/kernel/config/tsm/report"
+
+// TSM provider strings as written to the ConfigFS `provider` attribute (note
+// the trailing newline the kernel appends).
+const (
+	ProviderTdx = "tdx_guest\n"
+	ProviderSev = "sev_guest\n"
+	ProviderCca = "arm_cca_guest\n"
+)
+
+// Available reports whether the ConfigFS TSM_REPORT interface is present.
+func Available() bool {
+	_, err := os.Stat(basePath)
+	return err == nil
+}
+
+// GetReport drives one one-shot TSM_REPORT request through ConfigFS: it creates
+// a temporary report entry, verifies the provider, writes the report data to
+// `inblob`, reads the resulting `outblob` (the quote), and removes the entry.
+//
+// privlevel is only written for the SEV provider (pass -1 to skip).
+func GetReport(wantProvider string, reportData []byte, privlevel int) ([]byte, error) {
+	if !Available() {
+		return nil, fmt.Errorf("tsm: %s not available", basePath)
+	}
+
+	dir, err := os.MkdirTemp(basePath, "")
+	if err != nil {
+		return nil, fmt.Errorf("tsm: create report entry: %w", err)
+	}
+	defer func() { _ = os.Remove(dir) }()
+
+	if err := checkProvider(dir, wantProvider); err != nil {
+		return nil, err
+	}
+
+	if privlevel >= 0 {
+		if err := os.WriteFile(filepath.Join(dir, "privlevel"), []byte{byte(privlevel)}, 0o644); err != nil {
+			return nil, fmt.Errorf("tsm: write privlevel: %w", err)
+		}
+	}
+
+	if len(reportData) == 0 {
+		return nil, fmt.Errorf("tsm: empty inblob")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "inblob"), reportData, 0o644); err != nil {
+		return nil, fmt.Errorf("tsm: write inblob: %w", err)
+	}
+
+	outblob, err := os.ReadFile(filepath.Join(dir, "outblob"))
+	if err != nil {
+		return nil, fmt.Errorf("tsm: read outblob: %w", err)
+	}
+
+	if err := checkWriteRace(dir); err != nil {
+		return nil, err
+	}
+	return outblob, nil
+}
+
+func checkProvider(dir, wantProvider string) error {
+	got, err := os.ReadFile(filepath.Join(dir, "provider"))
+	if err != nil {
+		return fmt.Errorf("tsm: read provider: %w", err)
+	}
+	if string(got) != wantProvider {
+		return fmt.Errorf("tsm: missing provider: want %q got %q", wantProvider, string(got))
+	}
+	return nil
+}
+
+// checkWriteRace ensures no other writer raced on the same entry: the
+// `generation` counter must be exactly 1 after our single inblob write.
+func checkWriteRace(dir string) error {
+	g, err := os.ReadFile(filepath.Join(dir, "generation"))
+	if err != nil {
+		return fmt.Errorf("tsm: read generation: %w", err)
+	}
+	generation, err := strconv.ParseUint(strings.TrimSpace(string(g)), 10, 32)
+	if err != nil {
+		return fmt.Errorf("tsm: parse generation: %w", err)
+	}
+	if generation > 1 {
+		return fmt.Errorf("tsm: inblob write conflict (generation=%d)", generation)
+	}
+	return nil
+}

--- a/attestation-agent/attester-go/internal/util/util.go
+++ b/attestation-agent/attester-go/internal/util/util.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package util holds small helpers shared across the attester implementation.
+package util
+
+import "os"
+
+// Pad copies input into a fixed-size buffer of length n, truncating if input is
+// longer and zero-padding if shorter. Equivalent to the Rust utils::pad.
+func Pad(input []byte, n int) []byte {
+	out := make([]byte, n)
+	if len(input) > n {
+		copy(out, input[:n])
+	} else {
+		copy(out, input)
+	}
+	return out
+}
+
+// FileExists reports whether the given path exists.
+func FileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}

--- a/attestation-agent/attester-go/internal/util/util_test.go
+++ b/attestation-agent/attester-go/internal/util/util_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestPad(t *testing.T) {
+	if got := Pad([]byte{1, 2, 3}, 5); !bytes.Equal(got, []byte{1, 2, 3, 0, 0}) {
+		t.Fatalf("pad short = %v", got)
+	}
+	if got := Pad([]byte{1, 2, 3, 4, 5, 6}, 4); !bytes.Equal(got, []byte{1, 2, 3, 4}) {
+		t.Fatalf("pad long = %v", got)
+	}
+}

--- a/attestation-agent/attester-go/platform/csv/csv.go
+++ b/attestation-agent/attester-go/platform/csv/csv.go
@@ -1,0 +1,404 @@
+// Copyright (C) Hygon Info Technologies Ltd.
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package csv implements the Hygon CSV attester via /dev/csv-guest ioctls.
+package csv
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"unsafe"
+
+	"github.com/confidential-containers/guest-components/attestation-agent/attester-go/api"
+	"github.com/confidential-containers/guest-components/attestation-agent/attester-go/internal/eventlog"
+	"github.com/confidential-containers/guest-components/attestation-agent/attester-go/internal/ioctl"
+	"github.com/confidential-containers/guest-components/attestation-agent/attester-go/internal/sm3"
+	"github.com/confidential-containers/guest-components/attestation-agent/attester-go/internal/util"
+)
+
+const (
+	guestDevice = "/dev/csv-guest"
+
+	reportBufSize = 4096
+	rtmrRegSize   = 32
+
+	// V2 report layout offsets inside the 4096-byte report data.
+	v2SignerOffset = 1168
+	pekCertLen     = 2084
+	snLen          = 64
+	v2PekOffset    = v2SignerOffset // signer.pek_cert
+	v2SnOffset     = v2SignerOffset + pekCertLen
+
+	includeCertChainEnv = "CSV_INCLUDE_CERT_CHAIN_IN_ATTESTATION_REPORT"
+	kdsURL              = "https://cert.hygon.cn/hsk_cek?snumber="
+
+	hskCertLen = 832 // ca::Certificate serialized size
+)
+
+// CSV ioctl numbers (/dev/csv-guest).
+var (
+	cmdGetReport = ioctl.IOWR('D', 0x1, unsafe.Sizeof(reportRequest{}))
+	cmdRtmrReq   = ioctl.IOWR('D', 0x2, unsafe.Sizeof(rtmrRequest{}))
+)
+
+// reportRequest mirrors GuestReportRequest (16 bytes).
+type reportRequest struct {
+	Addr uint64
+	Len  uint32
+	_    uint32
+}
+
+// rtmrRequest mirrors GuestRtmrRequest (24 bytes, packed).
+type rtmrRequest struct {
+	Buf         uint64
+	Len         uint64
+	SubcmdID    uint16
+	Rsvd        uint16
+	FwErrorCode uint32
+}
+
+const (
+	rtmrRead   = 3
+	rtmrExtend = 4
+)
+
+// ---- evidence JSON structs (byte-compatible with the Rust CsvEvidence) ----
+
+// NumberBytes serializes like a Rust Vec<u8>: a JSON array of numbers.
+type NumberBytes []byte
+
+func (b NumberBytes) MarshalJSON() ([]byte, error) {
+	buf := make([]byte, 0, len(b)*4+2)
+	buf = append(buf, '[')
+	for i, v := range b {
+		if i > 0 {
+			buf = append(buf, ',')
+		}
+		buf = strconv.AppendUint(buf, uint64(v), 10)
+	}
+	buf = append(buf, ']')
+	return buf, nil
+}
+
+func (b *NumberBytes) UnmarshalJSON(data []byte) error {
+	var nums []uint8
+	if err := json.Unmarshal(data, &nums); err != nil {
+		return err
+	}
+	*b = nums
+	return nil
+}
+
+type Version struct {
+	Major uint8 `json:"major"`
+	Minor uint8 `json:"minor"`
+}
+
+type EccPubKey struct {
+	G uint32   `json:"g"`
+	X [72]byte `json:"x"`
+	Y [72]byte `json:"y"`
+}
+
+type EcdsaSignature struct {
+	R [72]byte `json:"r"`
+	S [72]byte `json:"s"`
+}
+
+// ---- ca::Certificate ----
+
+type CaData struct {
+	Kid      [16]byte `json:"kid"`
+	Sid      [16]byte `json:"sid"`
+	Usage    uint32   `json:"usage"`
+	Reserved [24]byte `json:"reserved"`
+}
+
+type CaPreamble struct {
+	Ver  uint32 `json:"ver"`
+	Data CaData `json:"data"`
+}
+
+type CaBody struct {
+	Preamble CaPreamble `json:"preamble"`
+	Pubkey   EccPubKey  `json:"pubkey"`
+	UidSize  uint16     `json:"uid_size"`
+	UserID   [254]byte  `json:"user_id"`
+	Reserved [108]byte  `json:"reserved"`
+}
+
+type CaCertificate struct {
+	Body      CaBody         `json:"body"`
+	Signature EcdsaSignature `json:"signature"`
+	Reserved  [112]byte      `json:"_reserved"`
+}
+
+// ---- csv::Certificate ----
+
+type KeyPubKey struct {
+	Usage uint32    `json:"usage"`
+	Algo  uint32    `json:"algo"`
+	Key   EccPubKey `json:"key"`
+}
+
+type Data struct {
+	Firmware  Version   `json:"firmware"`
+	Reserved1 uint16    `json:"reserved1"`
+	Pubkey    KeyPubKey `json:"pubkey"`
+	UidSize   uint16    `json:"uid_size"`
+	UserID    [254]byte `json:"user_id"`
+	Sid       [16]byte  `json:"sid"`
+	Reserved2 [608]byte `json:"reserved2"`
+}
+
+type Body struct {
+	Ver  uint32 `json:"ver"`
+	Data Data   `json:"data"`
+}
+
+type Signatures struct {
+	Usage     uint32         `json:"usage"`
+	Algo      uint32         `json:"algo"`
+	Signature EcdsaSignature `json:"signature"`
+	Reserved  [368]byte      `json:"_reserved"`
+}
+
+type Certificate struct {
+	Body Body          `json:"body"`
+	Sigs [2]Signatures `json:"sigs"`
+}
+
+// ---- top-level ----
+
+type HskCek struct {
+	Hsk CaCertificate `json:"hsk"`
+	Cek Certificate   `json:"cek"`
+}
+
+type CertificateChain struct {
+	HskCek *HskCek     `json:"hsk_cek,omitempty"`
+	Pek    Certificate `json:"pek"`
+}
+
+type AttestationReportWrapper struct {
+	Magic [16]byte   `json:"magic"`
+	Flags uint32     `json:"flags"`
+	Data  [4096]byte `json:"data"`
+}
+
+type Evidence struct {
+	AttestationReport AttestationReportWrapper `json:"attestation_report"`
+	CertChain         CertificateChain         `json:"cert_chain"`
+	SerialNumber      NumberBytes              `json:"serial_number"`
+	CcEventlog        *string                  `json:"cc_eventlog"`
+}
+
+// Attester collects Hygon CSV evidence.
+type Attester struct {
+	api.Base
+}
+
+// New creates a CSV Attester.
+func New() *Attester { return &Attester{} }
+
+// DetectPlatform reports whether the guest is a CSV guest.
+func DetectPlatform() bool {
+	return util.FileExists(guestDevice)
+}
+
+func (a *Attester) GetEvidence(reportData []byte) (api.TeeEvidence, error) {
+	if len(reportData) > 64 {
+		return nil, errors.New("CSV attester: report data must be <= 64 bytes")
+	}
+	report, err := getReportExt(util.Pad(reportData, 64))
+	if err != nil {
+		return nil, err
+	}
+
+	// AttestationReportWrapper: raw 4096 report + V2 magic/flags.
+	var wrapper AttestationReportWrapper
+	copy(wrapper.Magic[:], []byte("ATTESTATION_EXT\x00"))
+	wrapper.Flags = 1
+	copy(wrapper.Data[:], report)
+
+	// Extract PEK cert and serial number from the signer (V2 offsets).
+	var pek Certificate
+	if err := binary.Read(bytes.NewReader(report[v2PekOffset:v2PekOffset+pekCertLen]), binary.LittleEndian, &pek); err != nil {
+		return nil, fmt.Errorf("CSV attester: parse pek cert: %w", err)
+	}
+	sn := make([]byte, snLen)
+	copy(sn, report[v2SnOffset:v2SnOffset+snLen])
+
+	chain := CertificateChain{Pek: pek}
+	if os.Getenv(includeCertChainEnv) == "true" {
+		hskCek, err := downloadHskCek(sn)
+		if err != nil {
+			return nil, err
+		}
+		chain.HskCek = hskCek
+	}
+
+	ccEventlog, err := eventlog.Read()
+	if err != nil {
+		return nil, err
+	}
+
+	ev := Evidence{
+		AttestationReport: wrapper,
+		CertChain:         chain,
+		SerialNumber:      sn,
+		CcEventlog:        ccEventlog,
+	}
+	return json.Marshal(ev)
+}
+
+// getReportExt issues CSV_GET_REPORT (V2 extended) and returns the raw
+// 4096-byte report buffer.
+func getReportExt(reportData []byte) ([]byte, error) {
+	f, err := os.OpenFile(guestDevice, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", guestDevice, err)
+	}
+	defer f.Close()
+
+	buf := make([]byte, reportBufSize)
+	// V2 ReportReqExt at head: data[64], mnonce[16], hash[32], magic[16], flags u32
+	copy(buf[0:64], reportData)
+	var mnonce [16]byte
+	if _, err := rand.Read(mnonce[:]); err != nil {
+		return nil, err
+	}
+	copy(buf[64:80], mnonce[:])
+	h := sm3.Sum(append(append([]byte{}, reportData...), mnonce[:]...))
+	copy(buf[80:112], h[:])
+	copy(buf[112:128], []byte("ATTESTATION_EXT\x00"))
+	binary.LittleEndian.PutUint32(buf[128:132], 1) // flags
+
+	req := reportRequest{
+		Addr: uint64(uintptr(unsafe.Pointer(&buf[0]))),
+		Len:  reportBufSize,
+	}
+	if err := ioctl.Do(int(f.Fd()), cmdGetReport, unsafe.Pointer(&req)); err != nil {
+		return nil, fmt.Errorf("CSV_GET_REPORT ioctl: %w", err)
+	}
+	return buf, nil
+}
+
+func (a *Attester) ExtendRuntimeMeasurement(eventDigest []byte, registerIndex uint64) error {
+	if len(eventDigest) < rtmrRegSize {
+		return fmt.Errorf("CSV attester: extend data must be >= %d bytes", rtmrRegSize)
+	}
+	ccmr := a.PcrToCcmr(registerIndex)
+
+	// CsvGuestUserRtmrExtend: index u8, rsvd u8, data_len u16, data[32] (packed, 36B)
+	sub := make([]byte, 36)
+	sub[0] = uint8(ccmr)
+	binary.LittleEndian.PutUint16(sub[2:4], rtmrRegSize)
+	copy(sub[4:36], eventDigest[:rtmrRegSize])
+
+	return rtmrIoctl(rtmrExtend, sub)
+}
+
+func (a *Attester) GetRuntimeMeasurement(pcrIndex uint64) ([]byte, error) {
+	ccmr := a.PcrToCcmr(pcrIndex)
+	bitmap := uint32(1) << ccmr
+
+	// CsvGuestUserRtmrRead: bitmap u32, data[32*N]
+	n := popcount(bitmap & 0x1F)
+	sub := make([]byte, 4+rtmrRegSize*n)
+	binary.LittleEndian.PutUint32(sub[0:4], bitmap)
+
+	if err := rtmrIoctl(rtmrRead, sub); err != nil {
+		return nil, err
+	}
+	// single bit -> the register is the first one in the output
+	out := make([]byte, rtmrRegSize)
+	copy(out, sub[4:4+rtmrRegSize])
+	return out, nil
+}
+
+func rtmrIoctl(subcmd uint16, sub []byte) error {
+	f, err := os.OpenFile(guestDevice, os.O_RDONLY, 0)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", guestDevice, err)
+	}
+	defer f.Close()
+
+	req := rtmrRequest{
+		Buf:      uint64(uintptr(unsafe.Pointer(&sub[0]))),
+		Len:      uint64(len(sub)),
+		SubcmdID: subcmd,
+	}
+	if err := ioctl.Do(int(f.Fd()), cmdRtmrReq, unsafe.Pointer(&req)); err != nil {
+		return fmt.Errorf("CSV_RTMR_REQ ioctl: %w", err)
+	}
+	if req.FwErrorCode != 0 {
+		return fmt.Errorf("CSV_RTMR_REQ fw_error: 0x%x", req.FwErrorCode)
+	}
+	return nil
+}
+
+func (a *Attester) PcrToCcmr(pcrIndex uint64) uint64 {
+	switch {
+	case pcrIndex == 0:
+		return 0
+	case pcrIndex == 1 || pcrIndex == 7:
+		return 1
+	case pcrIndex >= 2 && pcrIndex <= 6:
+		return 2
+	case pcrIndex >= 8 && pcrIndex <= 15:
+		return 3
+	default:
+		return 4
+	}
+}
+
+func (a *Attester) CcelHashAlgorithm() api.HashAlgorithm { return api.HashSm3 }
+
+// downloadHskCek fetches the HSK (ca::Certificate) and CEK (csv::Certificate)
+// chain from the Hygon KDS, keyed by the chip serial number.
+func downloadHskCek(sn []byte) (*HskCek, error) {
+	chipID := strings.TrimRight(string(sn), "\x00")
+	resp, err := http.Get(kdsURL + chipID)
+	if err != nil {
+		return nil, fmt.Errorf("CSV attester: download HSK/CEK: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if len(body) < hskCertLen+pekCertLen {
+		return nil, fmt.Errorf("CSV attester: KDS response too short: %d", len(body))
+	}
+
+	var hsk CaCertificate
+	if err := binary.Read(bytes.NewReader(body[:hskCertLen]), binary.LittleEndian, &hsk); err != nil {
+		return nil, fmt.Errorf("CSV attester: parse HSK: %w", err)
+	}
+	var cek Certificate
+	if err := binary.Read(bytes.NewReader(body[hskCertLen:hskCertLen+pekCertLen]), binary.LittleEndian, &cek); err != nil {
+		return nil, fmt.Errorf("CSV attester: parse CEK: %w", err)
+	}
+	return &HskCek{Hsk: hsk, Cek: cek}, nil
+}
+
+func popcount(x uint32) int {
+	n := 0
+	for x != 0 {
+		n += int(x & 1)
+		x >>= 1
+	}
+	return n
+}

--- a/attestation-agent/attester-go/platform/csv/csv_test.go
+++ b/attestation-agent/attester-go/platform/csv/csv_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package csv
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSizes(t *testing.T) {
+	if got := binary.Size(Certificate{}); got != pekCertLen {
+		t.Fatalf("Certificate size = %d, want %d", got, pekCertLen)
+	}
+	if got := binary.Size(CaCertificate{}); got != hskCertLen {
+		t.Fatalf("CaCertificate size = %d, want %d", got, hskCertLen)
+	}
+	if got := binary.Size(reportRequest{}); got != 16 {
+		t.Fatalf("reportRequest size = %d, want 16", got)
+	}
+	if got := binary.Size(rtmrRequest{}); got != 24 {
+		t.Fatalf("rtmrRequest size = %d, want 24", got)
+	}
+}
+
+func TestEvidenceJSON(t *testing.T) {
+	var wrapper AttestationReportWrapper
+	copy(wrapper.Magic[:], []byte("ATTESTATION_EXT\x00"))
+	wrapper.Flags = 1
+
+	ev := Evidence{
+		AttestationReport: wrapper,
+		CertChain:         CertificateChain{}, // HskCek nil -> omitted
+		SerialNumber:      NumberBytes{1, 2, 3},
+		CcEventlog:        nil, // -> null
+	}
+	b, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+
+	for _, c := range []string{
+		`"serial_number":[1,2,3]`,
+		`"cc_eventlog":null`,
+		`"flags":1`,
+		`"magic":[65,84,84,69,83,84,65,84,73,79,78,95,69,88,84,0]`,
+	} {
+		if !strings.Contains(s, c) {
+			t.Errorf("CSV evidence JSON missing %q", c)
+		}
+	}
+	if strings.Contains(s, `"hsk_cek"`) {
+		t.Errorf("hsk_cek should be omitted when nil, got: %s", s)
+	}
+}

--- a/attestation-agent/attester-go/platform/sample/sample.go
+++ b/attestation-agent/attester-go/platform/sample/sample.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package sample implements the always-available software-backed attester.
+package sample
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/confidential-containers/guest-components/attestation-agent/attester-go/api"
+	"github.com/confidential-containers/guest-components/attestation-agent/attester-go/internal/eventlog"
+)
+
+const (
+	measureRegisterPath = "/run/attestation-agent/sample_measure_register"
+	measureDigestLen    = 32
+)
+
+// quote is the sample evidence. Field order matches the Rust SampleQuote.
+type quote struct {
+	Svn             string  `json:"svn"`
+	ReportData      string  `json:"report_data"`
+	MeasureRegister string  `json:"measure_register"`
+	CcEventlog      *string `json:"cc_eventlog"`
+}
+
+// DetectPlatform always returns true: the sample attester is the fallback.
+func DetectPlatform() bool { return true }
+
+// measureRegister is a minimal software-backed measurement register.
+type measureRegister struct {
+	path string
+	mu   sync.Mutex
+}
+
+func newMeasureRegister(path string) *measureRegister {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		if parent := filepath.Dir(path); parent != "" {
+			_ = os.MkdirAll(parent, 0o755)
+		}
+		zeros := make([]byte, measureDigestLen)
+		_ = os.WriteFile(path, []byte(hex.EncodeToString(zeros)), 0o644)
+	}
+	return &measureRegister{path: path}
+}
+
+func (m *measureRegister) currentValue() ([]byte, error) {
+	content, err := os.ReadFile(m.path)
+	if err != nil {
+		return nil, fmt.Errorf("read sample measure register %s: %w", m.path, err)
+	}
+	trimmed := strings.TrimSpace(string(content))
+	if trimmed == "" {
+		return nil, fmt.Errorf("sample measure register %s is empty", m.path)
+	}
+	decoded, err := hex.DecodeString(trimmed)
+	if err != nil {
+		return nil, fmt.Errorf("decode sample measure register %s: %w", m.path, err)
+	}
+	if len(decoded) != measureDigestLen {
+		return nil, fmt.Errorf("sample measure register length %d != %d", len(decoded), measureDigestLen)
+	}
+	return decoded, nil
+}
+
+func (m *measureRegister) store(value []byte) error {
+	if len(value) != measureDigestLen {
+		return fmt.Errorf("invalid measurement length %d, expected %d", len(value), measureDigestLen)
+	}
+	if parent := filepath.Dir(m.path); parent != "" {
+		if err := os.MkdirAll(parent, 0o755); err != nil {
+			return err
+		}
+	}
+	return os.WriteFile(m.path, []byte(hex.EncodeToString(value)), 0o644)
+}
+
+func (m *measureRegister) extend(eventDigest []byte) ([]byte, error) {
+	material, err := m.currentValue()
+	if err != nil {
+		return nil, err
+	}
+	material = append(material, eventDigest...)
+	updated := sha256.Sum256(material)
+	if err := m.store(updated[:]); err != nil {
+		return nil, err
+	}
+	return updated[:], nil
+}
+
+// Attester is the sample attester.
+type Attester struct {
+	api.Base
+	reg *measureRegister
+}
+
+// New creates a sample Attester.
+func New() *Attester {
+	return &Attester{reg: newMeasureRegister(measureRegisterPath)}
+}
+
+func (a *Attester) GetEvidence(reportData []byte) (api.TeeEvidence, error) {
+	a.reg.mu.Lock()
+	defer a.reg.mu.Unlock()
+
+	bytes, err := a.reg.currentValue()
+	if err != nil {
+		return nil, err
+	}
+	ccEventlog, err := eventlog.Read()
+	if err != nil {
+		return nil, err
+	}
+
+	ev := quote{
+		Svn:             "1",
+		ReportData:      base64.StdEncoding.EncodeToString(reportData),
+		MeasureRegister: hex.EncodeToString(bytes),
+		CcEventlog:      ccEventlog,
+	}
+	return json.Marshal(ev)
+}
+
+func (a *Attester) ExtendRuntimeMeasurement(eventDigest []byte, _ uint64) error {
+	if len(eventDigest) != measureDigestLen {
+		return fmt.Errorf("sample attester requires %d-byte digest (SHA256), got %d", measureDigestLen, len(eventDigest))
+	}
+	a.reg.mu.Lock()
+	defer a.reg.mu.Unlock()
+	_, err := a.reg.extend(eventDigest)
+	return err
+}
+
+func (a *Attester) GetRuntimeMeasurement(_ uint64) ([]byte, error) {
+	a.reg.mu.Lock()
+	defer a.reg.mu.Unlock()
+	return a.reg.currentValue()
+}
+
+// PcrToCcmr maps all PCR indices to a single simulated register.
+func (a *Attester) PcrToCcmr(_ uint64) uint64 { return 1 }
+
+func (a *Attester) CcelHashAlgorithm() api.HashAlgorithm { return api.HashSha256 }

--- a/attestation-agent/attester-go/platform/sample/sample_test.go
+++ b/attestation-agent/attester-go/platform/sample/sample_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package sample
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+func TestSampleAttester(t *testing.T) {
+	reg := newMeasureRegister(filepath.Join(t.TempDir(), "reg"))
+	a := &Attester{reg: reg}
+
+	ev, err := a.GetEvidence([]byte{1, 2, 3, 4, 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var q quote
+	if err := json.Unmarshal(ev, &q); err != nil {
+		t.Fatalf("evidence not valid JSON: %v (%s)", err, ev)
+	}
+	if q.Svn != "1" {
+		t.Errorf("svn = %q, want 1", q.Svn)
+	}
+	if got, _ := base64.StdEncoding.DecodeString(q.ReportData); !bytes.Equal(got, []byte{1, 2, 3, 4, 5}) {
+		t.Errorf("report_data roundtrip failed: %q", q.ReportData)
+	}
+	if len(q.MeasureRegister) != 64 {
+		t.Errorf("measure_register hex len = %d, want 64", len(q.MeasureRegister))
+	}
+
+	before, _ := reg.currentValue()
+	if err := a.ExtendRuntimeMeasurement(make([]byte, 32), 0); err != nil {
+		t.Fatal(err)
+	}
+	after, _ := reg.currentValue()
+	if bytes.Equal(before, after) {
+		t.Error("extend did not change measure register")
+	}
+
+	if err := a.ExtendRuntimeMeasurement(make([]byte, 16), 0); err == nil {
+		t.Error("expected error for 16-byte digest")
+	}
+}

--- a/attestation-agent/attester-go/platform/snp/snp.go
+++ b/attestation-agent/attester-go/platform/snp/snp.go
@@ -1,0 +1,361 @@
+// Copyright (c) 2022 IBM
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package snp implements the AMD SEV-SNP attester via /dev/sev-guest ioctls.
+package snp
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"unsafe"
+
+	"github.com/confidential-containers/guest-components/attestation-agent/attester-go/api"
+	"github.com/confidential-containers/guest-components/attestation-agent/attester-go/internal/ioctl"
+	"github.com/confidential-containers/guest-components/attestation-agent/attester-go/internal/util"
+)
+
+const (
+	guestDevice = "/dev/sev-guest"
+
+	reportOffset = 0x20  // report offset inside ReportRsp buffer
+	reportSize   = 0x4A0 // 1184
+	respBufSize  = 4000
+	hostDataOff  = reportOffset + 192 // host_data absolute offset
+
+	vmmErrInvalidCertPageLen = 0x1
+	vmmErrRateLimit          = 0x2
+)
+
+// SNP ioctl numbers (/dev/sev-guest), arg = guestRequest (32 bytes).
+var (
+	cmdGetReport    = ioctl.IOWR('S', 0x0, unsafe.Sizeof(guestRequest{}))
+	cmdGetExtReport = ioctl.IOWR('S', 0x2, unsafe.Sizeof(guestRequest{}))
+)
+
+// guestRequest mirrors the kernel snp_guest_request_ioctl (32 bytes).
+type guestRequest struct {
+	MessageVersion uint8
+	_              [7]byte
+	RequestData    uint64
+	ResponseData   uint64
+	FwErr          uint64
+}
+
+// reportRequest mirrors ReportReq (96 bytes).
+type reportRequest struct {
+	ReportData [64]byte
+	Vmpl       uint32
+	Reserved   [28]byte
+}
+
+// extReportRequest mirrors ExtReportReq (112 bytes).
+type extReportRequest struct {
+	Data         reportRequest
+	CertsAddress uint64
+	CertsLen     uint32
+	_            [4]byte
+}
+
+// ---- evidence JSON structs (byte-compatible with the Rust SnpEvidence) ----
+
+// ByteSlice serializes like a Rust Vec<u8>: a JSON array of numbers.
+type ByteSlice []byte
+
+func (b ByteSlice) MarshalJSON() ([]byte, error) {
+	out := make([]byte, 0, len(b)*4+2)
+	out = append(out, '[')
+	for i, v := range b {
+		if i > 0 {
+			out = append(out, ',')
+		}
+		out = strconv.AppendUint(out, uint64(v), 10)
+	}
+	out = append(out, ']')
+	return out, nil
+}
+
+func (b *ByteSlice) UnmarshalJSON(data []byte) error {
+	var nums []uint8
+	if err := json.Unmarshal(data, &nums); err != nil {
+		return err
+	}
+	*b = nums
+	return nil
+}
+
+// CertType serializes like the Rust CertType enum (external tagging): unit
+// variants -> bare string; OTHER(uuid) -> {"OTHER":"<uuid>"}.
+type CertType struct {
+	Name      string
+	OtherUUID string
+}
+
+func (c CertType) MarshalJSON() ([]byte, error) {
+	if c.Name == "OTHER" {
+		return json.Marshal(map[string]string{"OTHER": c.OtherUUID})
+	}
+	return json.Marshal(c.Name)
+}
+
+// TcbVersion mirrors sev::firmware::host::TcbVersion.
+type TcbVersion struct {
+	Bootloader uint8    `json:"bootloader"`
+	Tee        uint8    `json:"tee"`
+	Reserved   [4]uint8 `json:"_reserved"`
+	Snp        uint8    `json:"snp"`
+	Microcode  uint8    `json:"microcode"`
+}
+
+// Signature mirrors sev::certs::snp::ecdsa::Signature.
+type Signature struct {
+	R        [72]uint8  `json:"r"`
+	S        [72]uint8  `json:"s"`
+	Reserved [368]uint8 `json:"_reserved"`
+}
+
+// AttestationReport mirrors sev::firmware::guest::AttestationReport. Its field
+// order and types also match the raw 1184-byte report, so it can be filled
+// directly with binary.Read (little-endian).
+type AttestationReport struct {
+	Version         uint32     `json:"version"`
+	GuestSvn        uint32     `json:"guest_svn"`
+	Policy          uint64     `json:"policy"`
+	FamilyID        [16]uint8  `json:"family_id"`
+	ImageID         [16]uint8  `json:"image_id"`
+	Vmpl            uint32     `json:"vmpl"`
+	SigAlgo         uint32     `json:"sig_algo"`
+	CurrentTcb      TcbVersion `json:"current_tcb"`
+	PlatInfo        uint64     `json:"plat_info"`
+	AuthorKeyEn     uint32     `json:"_author_key_en"`
+	Reserved0       uint32     `json:"_reserved_0"`
+	ReportData      [64]uint8  `json:"report_data"`
+	Measurement     [48]uint8  `json:"measurement"`
+	HostData        [32]uint8  `json:"host_data"`
+	IDKeyDigest     [48]uint8  `json:"id_key_digest"`
+	AuthorKeyDigest [48]uint8  `json:"author_key_digest"`
+	ReportID        [32]uint8  `json:"report_id"`
+	ReportIDMa      [32]uint8  `json:"report_id_ma"`
+	ReportedTcb     TcbVersion `json:"reported_tcb"`
+	Reserved1       [24]uint8  `json:"_reserved_1"`
+	ChipID          [64]uint8  `json:"chip_id"`
+	CommittedTcb    TcbVersion `json:"committed_tcb"`
+	CurrentBuild    uint8      `json:"current_build"`
+	CurrentMinor    uint8      `json:"current_minor"`
+	CurrentMajor    uint8      `json:"current_major"`
+	Reserved2       uint8      `json:"_reserved_2"`
+	CommittedBuild  uint8      `json:"committed_build"`
+	CommittedMinor  uint8      `json:"committed_minor"`
+	CommittedMajor  uint8      `json:"committed_major"`
+	Reserved3       uint8      `json:"_reserved_3"`
+	LaunchTcb       TcbVersion `json:"launch_tcb"`
+	Reserved4       [168]uint8 `json:"_reserved_4"`
+	Signature       Signature  `json:"signature"`
+}
+
+// CertTableEntry mirrors sev::firmware::host::CertTableEntry.
+type CertTableEntry struct {
+	CertType CertType  `json:"cert_type"`
+	Data     ByteSlice `json:"data"`
+}
+
+// Evidence mirrors the attester/verifier SnpEvidence.
+type Evidence struct {
+	AttestationReport AttestationReport `json:"attestation_report"`
+	CertChain         []CertTableEntry  `json:"cert_chain"`
+}
+
+// Attester collects AMD SEV-SNP evidence.
+type Attester struct {
+	api.Base
+}
+
+// New creates an SNP Attester.
+func New() *Attester { return &Attester{} }
+
+// DetectPlatform reports whether the guest is an SEV-SNP guest.
+func DetectPlatform() bool {
+	return util.FileExists("/sys/devices/platform/sev-guest")
+}
+
+func (a *Attester) GetEvidence(reportData []byte) (api.TeeEvidence, error) {
+	if len(reportData) > 64 {
+		return nil, errors.New("SNP attester: report data must be <= 64 bytes")
+	}
+	report, certs, err := getExtendedReport(util.Pad(reportData, 64))
+	if err != nil {
+		return nil, err
+	}
+
+	var ar AttestationReport
+	if err := binary.Read(bytes.NewReader(report), binary.LittleEndian, &ar); err != nil {
+		return nil, fmt.Errorf("SNP attester: parse report: %w", err)
+	}
+
+	ev := Evidence{AttestationReport: ar, CertChain: certs}
+	return json.Marshal(ev)
+}
+
+func (a *Attester) BindInitData(initDataDigest []byte) (api.InitDataResult, error) {
+	resp, err := getReportRaw(make([]byte, 64))
+	if err != nil {
+		return api.InitDataUnsupported, err
+	}
+	if len(resp) < hostDataOff+32 {
+		return api.InitDataUnsupported, errors.New("SNP attester: response too short")
+	}
+	hostData := resp[hostDataOff : hostDataOff+32]
+	if !bytes.Equal(util.Pad(initDataDigest, 32), hostData) {
+		return api.InitDataUnsupported, errors.New("SNP attester: HOSTDATA does not match")
+	}
+	return api.InitDataOk, nil
+}
+
+// getReportRaw performs SNP_GET_REPORT and returns the raw response buffer.
+func getReportRaw(reportData []byte) ([]byte, error) {
+	f, err := os.OpenFile(guestDevice, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", guestDevice, err)
+	}
+	defer f.Close()
+
+	resp := make([]byte, respBufSize)
+	var req reportRequest
+	copy(req.ReportData[:], util.Pad(reportData, 64))
+
+	gr := guestRequest{
+		MessageVersion: 1,
+		RequestData:    uint64(uintptr(unsafe.Pointer(&req))),
+		ResponseData:   uint64(uintptr(unsafe.Pointer(&resp[0]))),
+	}
+	if err := ioctl.Do(int(f.Fd()), cmdGetReport, unsafe.Pointer(&gr)); err != nil {
+		return nil, fmt.Errorf("SNP_GET_REPORT ioctl: %w", err)
+	}
+	if uint32(gr.FwErr) != 0 {
+		return nil, fmt.Errorf("SNP_GET_REPORT fw_error: 0x%x", uint32(gr.FwErr))
+	}
+	return resp, nil
+}
+
+// getExtendedReport performs SNP_GET_EXT_REPORT, retrying once to size the
+// certificate buffer, and returns the raw report bytes and parsed cert chain.
+func getExtendedReport(reportData []byte) ([]byte, []CertTableEntry, error) {
+	f, err := os.OpenFile(guestDevice, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open %s: %w", guestDevice, err)
+	}
+	defer f.Close()
+
+	resp := make([]byte, respBufSize)
+	ext := extReportRequest{CertsAddress: ^uint64(0), CertsLen: 0}
+	copy(ext.Data.ReportData[:], reportData)
+
+	call := func() (uint32, error) {
+		gr := guestRequest{
+			MessageVersion: 1,
+			RequestData:    uint64(uintptr(unsafe.Pointer(&ext))),
+			ResponseData:   uint64(uintptr(unsafe.Pointer(&resp[0]))),
+		}
+		if err := ioctl.Do(int(f.Fd()), cmdGetExtReport, unsafe.Pointer(&gr)); err != nil {
+			return uint32(gr.FwErr >> 32), fmt.Errorf("SNP_GET_EXT_REPORT ioctl: %w", err)
+		}
+		return uint32(gr.FwErr >> 32), nil
+	}
+
+	var certsBuf []byte
+	vmmErr, ioErr := call()
+	if vmmErr == vmmErrInvalidCertPageLen {
+		// firmware wrote the required length into CertsLen; retry.
+		certsBuf = make([]byte, ext.CertsLen)
+		if len(certsBuf) > 0 {
+			ext.CertsAddress = uint64(uintptr(unsafe.Pointer(&certsBuf[0])))
+		}
+		vmmErr, ioErr = call()
+	}
+	if vmmErr == vmmErrRateLimit {
+		return nil, nil, errors.New("SNP attester: rate limit, retry required")
+	}
+	if ioErr != nil && vmmErr != 0 {
+		return nil, nil, ioErr
+	}
+
+	report := make([]byte, reportSize)
+	copy(report, resp[reportOffset:reportOffset+reportSize])
+
+	certs := parseCertTable(certsBuf)
+	return report, certs, nil
+}
+
+// known AMD certificate GUIDs (standard big-endian string order).
+var certGuids = map[string]string{
+	"c0b406a4-a803-4952-9743-3fb6014cd0ae": "ARK",
+	"4ab7b379-bbac-4fe4-a02f-05aef327c782": "ASK",
+	"63da758d-e664-4564-adc5-f4b93be8accd": "VCEK",
+	"a8074bc2-a25a-483e-aae6-39c045a0b8a1": "VLEK",
+	"92f81bc3-5811-4d3d-97ff-d19f88dc67ea": "CRL",
+}
+
+// parseCertTable parses the GET_EXT_REPORT certificate table (24-byte entries
+// terminated by an all-zero GUID). Returns nil when empty (-> JSON null).
+func parseCertTable(buf []byte) []CertTableEntry {
+	if len(buf) < 24 {
+		return nil
+	}
+	var out []CertTableEntry
+	for off := 0; off+24 <= len(buf); off += 24 {
+		guid := buf[off : off+16]
+		if isZero(guid) {
+			break
+		}
+		coff := binary.LittleEndian.Uint32(buf[off+16 : off+20])
+		clen := binary.LittleEndian.Uint32(buf[off+20 : off+24])
+		if int(coff)+int(clen) > len(buf) {
+			break
+		}
+		data := make([]byte, clen)
+		copy(data, buf[coff:coff+clen])
+
+		guidStr := formatGUID(guid)
+		ct := CertType{}
+		if name, ok := certGuids[guidStr]; ok {
+			ct.Name = name
+		} else {
+			ct.Name = "OTHER"
+			ct.OtherUUID = guidStr
+		}
+		out = append(out, CertTableEntry{CertType: ct, Data: data})
+	}
+	return out
+}
+
+func isZero(b []byte) bool {
+	for _, v := range b {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// formatGUID renders 16 bytes as a standard big-endian UUID string.
+func formatGUID(b []byte) string {
+	const hexd = "0123456789abcdef"
+	var sb [36]byte
+	j := 0
+	for i := 0; i < 16; i++ {
+		if i == 4 || i == 6 || i == 8 || i == 10 {
+			sb[j] = '-'
+			j++
+		}
+		sb[j] = hexd[b[i]>>4]
+		sb[j+1] = hexd[b[i]&0xF]
+		j += 2
+	}
+	return string(sb[:])
+}

--- a/attestation-agent/attester-go/platform/snp/snp_test.go
+++ b/attestation-agent/attester-go/platform/snp/snp_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package snp
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSizes(t *testing.T) {
+	if got := binary.Size(AttestationReport{}); got != reportSize {
+		t.Fatalf("AttestationReport size = %d, want %d", got, reportSize)
+	}
+	if got := binary.Size(guestRequest{}); got != 32 {
+		t.Fatalf("guestRequest size = %d, want 32", got)
+	}
+	if got := binary.Size(reportRequest{}); got != 96 {
+		t.Fatalf("reportRequest size = %d, want 96", got)
+	}
+	if got := binary.Size(extReportRequest{}); got != 112 {
+		t.Fatalf("extReportRequest size = %d, want 112", got)
+	}
+}
+
+func TestEvidenceJSON(t *testing.T) {
+	var ar AttestationReport
+	ar.Version = 2
+	ar.Policy = 196608 // GuestPolicy(u64) -> bare number
+	ar.ReportData[0] = 1
+
+	ev := Evidence{AttestationReport: ar, CertChain: nil}
+	b, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+
+	for _, c := range []string{
+		`"policy":196608`,
+		`"_author_key_en":0`,
+		`"_reserved_0":0`,
+		`"report_data":[1,0,0,`,
+		`"current_tcb":{"bootloader":0,"tee":0,"_reserved":[0,0,0,0],"snp":0,"microcode":0}`,
+		`"signature":{"r":[`,
+		`"cert_chain":null`,
+	} {
+		if !strings.Contains(s, c) {
+			t.Errorf("SNP evidence JSON missing %q\ngot: %s", c, s)
+		}
+	}
+}
+
+func TestCertEntryJSON(t *testing.T) {
+	e := CertTableEntry{CertType: CertType{Name: "VCEK"}, Data: ByteSlice{48, 130, 5}}
+	if b, _ := json.Marshal(e); string(b) != `{"cert_type":"VCEK","data":[48,130,5]}` {
+		t.Fatalf("cert entry JSON = %s", b)
+	}
+	other := CertTableEntry{
+		CertType: CertType{Name: "OTHER", OtherUUID: "12345678-1234-1234-1234-123456789abc"},
+		Data:     ByteSlice{},
+	}
+	want := `{"cert_type":{"OTHER":"12345678-1234-1234-1234-123456789abc"},"data":[]}`
+	if b, _ := json.Marshal(other); string(b) != want {
+		t.Fatalf("OTHER cert entry JSON = %s", b)
+	}
+}

--- a/attestation-agent/attester-go/platform/tdx/gpu.go
+++ b/attestation-agent/attester-go/platform/tdx/gpu.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build gpu
+
+// This file is only compiled with `-tags gpu`. It uses github.com/NVIDIA/go-nvml
+// which dlopen()s libnvidia-ml at runtime, so a binary built with this tag still
+// starts on machines without an NVIDIA driver (GPU evidence is simply skipped).
+package tdx
+
+import (
+	"encoding/base64"
+	"log"
+	"time"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+)
+
+// collectGpuEvidence collects confidential-computing evidence from all NVIDIA
+// GPUs, mirroring tdx::gpu::evidence::GpuEvidenceCollector. Any failure to
+// initialise NVML or query a device is non-fatal and yields nil / a partial
+// list, matching the Rust best-effort behaviour.
+func collectGpuEvidence(reportData []byte) *GpuEvidenceList {
+	if ret := nvml.Init(); ret != nvml.SUCCESS {
+		log.Printf("GPU: NVML init failed (%s), skipping GPU evidence", nvml.ErrorString(ret))
+		return nil
+	}
+	defer nvml.Shutdown()
+
+	count, ret := nvml.DeviceGetCount()
+	if ret != nvml.SUCCESS || count == 0 {
+		return nil
+	}
+
+	var nonce [32]byte
+	switch {
+	case len(reportData) == 0:
+		// leave zero
+	case len(reportData) <= 32:
+		copy(nonce[:], reportData)
+	default:
+		copy(nonce[:], reportData[:32])
+	}
+
+	driverVersion, _ := nvml.SystemGetDriverVersion()
+
+	ccEnabled := false
+	if state, ret := nvml.SystemGetConfComputeState(); ret == nvml.SUCCESS {
+		ccEnabled = state.CcFeature != 0
+	}
+
+	list := &GpuEvidenceList{CollectionTime: time.Now().UTC()}
+	for i := 0; i < count; i++ {
+		device, ret := nvml.DeviceGetHandleByIndex(i)
+		if ret != nvml.SUCCESS {
+			log.Printf("GPU: get handle %d failed: %s", i, nvml.ErrorString(ret))
+			continue
+		}
+		uuid, _ := device.GetUUID()
+		name, _ := device.GetName()
+		vbios, _ := device.GetVbiosVersion()
+
+		ev := GpuEvidence{
+			Index:         uint32(i),
+			UUID:          uuid,
+			Name:          name,
+			DriverVersion: driverVersion,
+			VbiosVersion:  vbios,
+			CcEnabled:     ccEnabled,
+		}
+
+		report := nvml.ConfComputeGpuAttestationReport{Nonce: nonce}
+		if ret := nvml.DeviceGetConfComputeGpuAttestationReport(device, &report); ret == nvml.SUCCESS {
+			b := base64.StdEncoding.EncodeToString(report.AttestationReport[:report.AttestationReportSize])
+			ev.AttestationReport = &b
+		} else {
+			log.Printf("GPU %d: get attestation report failed: %s", i, nvml.ErrorString(ret))
+		}
+
+		if ccEnabled {
+			if cert, ret := nvml.DeviceGetConfComputeGpuCertificate(device); ret == nvml.SUCCESS {
+				b := base64.StdEncoding.EncodeToString(cert.AttestationCertChain[:cert.AttestationCertChainSize])
+				ev.Certificate = &b
+			} else {
+				log.Printf("GPU %d: get certificate failed: %s", i, nvml.ErrorString(ret))
+			}
+		}
+
+		list.EvidenceList = append(list.EvidenceList, ev)
+	}
+
+	if len(list.EvidenceList) == 0 {
+		return nil
+	}
+	return list
+}

--- a/attestation-agent/attester-go/platform/tdx/gpu_stub.go
+++ b/attestation-agent/attester-go/platform/tdx/gpu_stub.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !gpu
+
+package tdx
+
+// collectGpuEvidence is a no-op in the default (pure-Go, no-cgo) build. Build
+// with `-tags gpu` to enable NVIDIA GPU evidence collection via go-nvml.
+func collectGpuEvidence(_ []byte) *GpuEvidenceList {
+	return nil
+}

--- a/attestation-agent/attester-go/platform/tdx/gpu_types.go
+++ b/attestation-agent/attester-go/platform/tdx/gpu_types.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tdx
+
+import "time"
+
+// GpuEvidence is per-GPU attestation evidence. Field order and tags match the
+// Rust tdx::gpu::evidence::GpuEvidence.
+type GpuEvidence struct {
+	Index             uint32  `json:"index"`
+	UUID              string  `json:"uuid"`
+	Name              string  `json:"name"`
+	DriverVersion     string  `json:"driver_version"`
+	VbiosVersion      string  `json:"vbios_version"`
+	AttestationReport *string `json:"attestation_report"`
+	Certificate       *string `json:"certificate"`
+	CcEnabled         bool    `json:"cc_enabled"`
+}
+
+// GpuEvidenceList is the collection of per-GPU evidence with a collection
+// timestamp. Matches the Rust GpuEvidenceList.
+type GpuEvidenceList struct {
+	EvidenceList   []GpuEvidence `json:"evidence_list"`
+	CollectionTime time.Time     `json:"collection_time"`
+}

--- a/attestation-agent/attester-go/platform/tdx/qgs.go
+++ b/attestation-agent/attester-go/platform/tdx/qgs.go
@@ -1,0 +1,267 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tdx
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/confidential-containers/guest-components/attestation-agent/attester-go/internal/ioctl"
+)
+
+// QGS message / transport constants, from Intel DCAP (tdx_attest.c, qgs_msg_lib).
+const (
+	qgsMsgMajorVer = 1
+	qgsMsgMinorVer = 1
+
+	qgsGetQuoteReq  = 0 // qgs_msg_type_t::GET_QUOTE_REQ
+	qgsGetQuoteResp = 1 // qgs_msg_type_t::GET_QUOTE_RESP
+
+	qgsHeaderLen = 16 // qgs_msg_header_t
+	blobHeader   = 4  // big-endian length prefix (HEADER_SIZE)
+	reqBufSize   = 4 * 4 * 1024
+
+	tdxAttestConf = "/etc/tdx-attest.conf"
+
+	getQuoteInFlight           = 0xffffffffffffffff
+	getQuoteServiceUnavailable = 0x8000000000000001
+)
+
+// errTransportUnsupported means this transport is not usable in the current
+// environment; the caller should try the next one.
+var errTransportUnsupported = errors.New("tdx: quote transport not supported")
+
+// buildGetQuoteReq serializes a QGS GET_QUOTE_REQ carrying the whole 1024-byte
+// TDREPORT (id list empty). Mirrors qgs_msg_gen_get_quote_req.
+func buildGetQuoteReq(tdreport []byte) []byte {
+	reportSize := uint32(len(tdreport))
+	msgSize := qgsHeaderLen + 4 + 4 + int(reportSize)
+	msg := make([]byte, msgSize)
+	// qgs_msg_header_t (little-endian native fields).
+	binary.LittleEndian.PutUint16(msg[0:], qgsMsgMajorVer)
+	binary.LittleEndian.PutUint16(msg[2:], qgsMsgMinorVer)
+	binary.LittleEndian.PutUint32(msg[4:], qgsGetQuoteReq)
+	binary.LittleEndian.PutUint32(msg[8:], uint32(msgSize))
+	binary.LittleEndian.PutUint32(msg[12:], 0) // error_code
+	// body
+	binary.LittleEndian.PutUint32(msg[16:], reportSize)
+	binary.LittleEndian.PutUint32(msg[20:], 0) // id_list_size
+	copy(msg[24:], tdreport)
+	return msg
+}
+
+// parseGetQuoteResp extracts the quote from a QGS GET_QUOTE_RESP message.
+// Mirrors qgs_msg_inflate_get_quote_resp + extract_quote_from_blob_payload.
+func parseGetQuoteResp(msg []byte) ([]byte, error) {
+	if len(msg) < qgsHeaderLen+8 {
+		return nil, fmt.Errorf("tdx: qgs resp too short: %d", len(msg))
+	}
+	major := binary.LittleEndian.Uint16(msg[0:])
+	typ := binary.LittleEndian.Uint32(msg[4:])
+	size := binary.LittleEndian.Uint32(msg[8:])
+	errCode := binary.LittleEndian.Uint32(msg[12:])
+	if major != qgsMsgMajorVer {
+		return nil, fmt.Errorf("tdx: qgs resp bad version: %d", major)
+	}
+	if typ != qgsGetQuoteResp {
+		return nil, fmt.Errorf("tdx: qgs resp bad type: %d", typ)
+	}
+	if errCode != 0 {
+		return nil, fmt.Errorf("tdx: qgs resp error_code: 0x%x", errCode)
+	}
+	if int(size) > len(msg) {
+		return nil, fmt.Errorf("tdx: qgs resp size %d > buffer %d", size, len(msg))
+	}
+	selectedIDSize := binary.LittleEndian.Uint32(msg[16:])
+	quoteSize := binary.LittleEndian.Uint32(msg[20:])
+	start := qgsHeaderLen + 8 + int(selectedIDSize)
+	if start+int(quoteSize) > len(msg) {
+		return nil, fmt.Errorf("tdx: qgs resp quote out of range")
+	}
+	quote := make([]byte, quoteSize)
+	copy(quote, msg[start:start+int(quoteSize)])
+	return quote, nil
+}
+
+// getVsockPort parses `port = N` from /etc/tdx-attest.conf, returning
+// unsupported when absent.
+var vsockPortRe = regexp.MustCompile(`(?m)^\s*port\s*=\s*([0-9]{1,10})`)
+
+func getVsockPort() (uint32, error) {
+	data, err := os.ReadFile(tdxAttestConf)
+	if err != nil {
+		return 0, errTransportUnsupported
+	}
+	m := vsockPortRe.FindSubmatch(data)
+	if m == nil {
+		return 0, errTransportUnsupported
+	}
+	var port uint64
+	for _, c := range m[1] {
+		port = port*10 + uint64(c-'0')
+	}
+	if port > 0xFFFF {
+		return 0, errTransportUnsupported
+	}
+	return uint32(port), nil
+}
+
+// vsockGetQuote sends the QGS request over vsock to the host QGS and returns the
+// raw response QGS message. Mirrors vsock_get_quote_payload.
+func vsockGetQuote(qgsMsg []byte) ([]byte, error) {
+	port, err := getVsockPort()
+	if err != nil {
+		return nil, err
+	}
+
+	fd, err := unix.Socket(unix.AF_VSOCK, unix.SOCK_STREAM, 0)
+	if err != nil {
+		return nil, fmt.Errorf("tdx: vsock socket: %w", err)
+	}
+	defer unix.Close(fd)
+
+	sa := &unix.SockaddrVM{CID: unix.VMADDR_CID_HOST, Port: port}
+	if err := unix.Connect(fd, sa); err != nil {
+		return nil, fmt.Errorf("tdx: vsock connect: %w", err)
+	}
+
+	// payload = [4B big-endian msg_size][qgs_msg]
+	payload := make([]byte, blobHeader+len(qgsMsg))
+	binary.BigEndian.PutUint32(payload[:blobHeader], uint32(len(qgsMsg)))
+	copy(payload[blobHeader:], qgsMsg)
+	if err := writeAll(fd, payload); err != nil {
+		return nil, fmt.Errorf("tdx: vsock send: %w", err)
+	}
+
+	// read 4-byte big-endian body size, then body
+	hdr := make([]byte, blobHeader)
+	if err := readFull(fd, hdr); err != nil {
+		return nil, fmt.Errorf("tdx: vsock recv header: %w", err)
+	}
+	bodySize := binary.BigEndian.Uint32(hdr)
+	if int(bodySize) > reqBufSize {
+		return nil, fmt.Errorf("tdx: vsock body too big: %d", bodySize)
+	}
+	body := make([]byte, bodySize)
+	if err := readFull(fd, body); err != nil {
+		return nil, fmt.Errorf("tdx: vsock recv body: %w", err)
+	}
+	return body, nil
+}
+
+func writeAll(fd int, b []byte) error {
+	for len(b) > 0 {
+		n, err := unix.Write(fd, b)
+		if err != nil {
+			return err
+		}
+		b = b[n:]
+	}
+	return nil
+}
+
+func readFull(fd int, b []byte) error {
+	for len(b) > 0 {
+		n, err := unix.Read(fd, b)
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return errors.New("unexpected EOF")
+		}
+		b = b[n:]
+	}
+	return nil
+}
+
+// quoteReq mirrors `struct tdx_quote_req { __u64 buf; __u64 len; }`.
+type quoteReq struct {
+	Buf uint64
+	Len uint64
+}
+
+// TDX_CMD_GET_QUOTE ioctl number encoding differs between kernel driver
+// versions (upstream vs. backports use different _IOC direction bits). Try each
+// until one is accepted (i.e. not ENOTTY).
+var cmdGetQuoteVariants = []uintptr{
+	ioctl.IOR('T', 4, unsafe.Sizeof(quoteReq{})),
+	ioctl.IOWR('T', 4, unsafe.Sizeof(quoteReq{})),
+	ioctl.IOW('T', 4, unsafe.Sizeof(quoteReq{})),
+}
+
+// tdcallGetQuote asks the kernel (GetQuote TDVMCALL, TDX_CMD_GET_QUOTE ioctl) to
+// forward the QGS request to the host and returns the response QGS message.
+// Mirrors tdcall_get_quote_payload.
+func tdcallGetQuote(qgsMsg []byte) ([]byte, error) {
+	f, err := os.OpenFile(guestDevice, os.O_RDWR|os.O_SYNC, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", guestDevice, err)
+	}
+	defer f.Close()
+
+	// blob layout: version u64 | status u64 | in_len u32 | out_len u32 |
+	//              [4B BE msg_size][qgs_msg]
+	blob := make([]byte, reqBufSize)
+	const dataOff = 24
+	inLen := blobHeader + len(qgsMsg)
+	if dataOff+inLen > reqBufSize {
+		return nil, fmt.Errorf("tdx: request too big for blob")
+	}
+	binary.LittleEndian.PutUint64(blob[0:], 1) // version
+	binary.LittleEndian.PutUint64(blob[8:], 0) // status
+	binary.LittleEndian.PutUint32(blob[16:], uint32(inLen))
+	binary.LittleEndian.PutUint32(blob[20:], 0) // out_len
+	binary.BigEndian.PutUint32(blob[dataOff:], uint32(len(qgsMsg)))
+	copy(blob[dataOff+blobHeader:], qgsMsg)
+
+	arg := quoteReq{
+		Buf: uint64(uintptr(unsafe.Pointer(&blob[0]))),
+		Len: reqBufSize,
+	}
+
+	var ioErr error
+	accepted := false
+	for _, req := range cmdGetQuoteVariants {
+		ioErr = ioctl.Do(int(f.Fd()), req, unsafe.Pointer(&arg))
+		if errors.Is(ioErr, unix.ENOTTY) {
+			continue // wrong ioctl number for this kernel, try next encoding
+		}
+		accepted = true
+		break
+	}
+	if !accepted {
+		return nil, fmt.Errorf("tdx: TDX_CMD_GET_QUOTE not supported by kernel: %w", ioErr)
+	}
+	if ioErr != nil {
+		return nil, fmt.Errorf("tdx: TDX_CMD_GET_QUOTE ioctl: %w", ioErr)
+	}
+
+	status := binary.LittleEndian.Uint64(blob[8:])
+	outLen := binary.LittleEndian.Uint32(blob[20:])
+	if status != 0 || outLen <= blobHeader {
+		switch status {
+		case getQuoteInFlight:
+			return nil, errors.New("tdx: get quote in flight")
+		case getQuoteServiceUnavailable:
+			return nil, errTransportUnsupported
+		default:
+			return nil, fmt.Errorf("tdx: get quote status=0x%x", status)
+		}
+	}
+
+	bodySize := binary.BigEndian.Uint32(blob[dataOff:])
+	if bodySize != outLen-blobHeader {
+		return nil, fmt.Errorf("tdx: body size mismatch: %d vs %d", bodySize, outLen-blobHeader)
+	}
+	body := make([]byte, bodySize)
+	copy(body, blob[dataOff+blobHeader:dataOff+blobHeader+int(bodySize)])
+	return body, nil
+}

--- a/attestation-agent/attester-go/platform/tdx/qgs_test.go
+++ b/attestation-agent/attester-go/platform/tdx/qgs_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tdx
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func TestQgsRoundtrip(t *testing.T) {
+	tdreport := make([]byte, tdReportSize)
+	tdreport[0] = 0x42
+	req := buildGetQuoteReq(tdreport)
+
+	if binary.LittleEndian.Uint16(req[0:]) != qgsMsgMajorVer {
+		t.Error("bad major version")
+	}
+	if binary.LittleEndian.Uint32(req[4:]) != qgsGetQuoteReq {
+		t.Error("bad msg type")
+	}
+	if int(binary.LittleEndian.Uint32(req[8:])) != len(req) {
+		t.Error("bad size field")
+	}
+	if binary.LittleEndian.Uint32(req[16:]) != uint32(tdReportSize) {
+		t.Error("bad report_size")
+	}
+	if req[24] != 0x42 {
+		t.Error("report not embedded")
+	}
+
+	quote := []byte{0xde, 0xad, 0xbe, 0xef}
+	resp := make([]byte, qgsHeaderLen+8+len(quote))
+	binary.LittleEndian.PutUint16(resp[0:], qgsMsgMajorVer)
+	binary.LittleEndian.PutUint16(resp[2:], qgsMsgMinorVer)
+	binary.LittleEndian.PutUint32(resp[4:], qgsGetQuoteResp)
+	binary.LittleEndian.PutUint32(resp[8:], uint32(len(resp)))
+	binary.LittleEndian.PutUint32(resp[12:], 0)
+	binary.LittleEndian.PutUint32(resp[16:], 0)
+	binary.LittleEndian.PutUint32(resp[20:], uint32(len(quote)))
+	copy(resp[24:], quote)
+
+	got, err := parseGetQuoteResp(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, quote) {
+		t.Fatalf("parsed quote = %v, want %v", got, quote)
+	}
+}

--- a/attestation-agent/attester-go/platform/tdx/report.go
+++ b/attestation-agent/attester-go/platform/tdx/report.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tdx
+
+import (
+	"fmt"
+	"os"
+	"unsafe"
+
+	"github.com/confidential-containers/guest-components/attestation-agent/attester-go/internal/ioctl"
+	"github.com/confidential-containers/guest-components/attestation-agent/attester-go/internal/util"
+)
+
+const (
+	guestDevice = "/dev/tdx_guest"
+
+	reportDataSize = 64
+	tdReportSize   = 1024
+
+	// Byte offsets into the 1024-byte TDREPORT (see attester tdx/report.rs).
+	offsetMrConfigID = 576 // TdInfo.mrconfigid [48]
+	lenMrConfigID    = 48
+	offsetRtmr       = 720 // TdInfo.rtmr [24]u64
+	rtmrEntryLen     = 48  // 6 * u64
+)
+
+// reportReq mirrors `struct tdx_report_req` used by TDX_CMD_GET_REPORT0.
+type reportReq struct {
+	ReportData [reportDataSize]byte
+	TdReport   [tdReportSize]byte
+}
+
+var cmdGetReport0 = ioctl.IOWR('T', 1, unsafe.Sizeof(reportReq{}))
+
+// getTdReport issues TDX_CMD_GET_REPORT0 to obtain the raw 1024-byte TDREPORT
+// bound to reportData (64 bytes).
+func getTdReport(reportData []byte) ([]byte, error) {
+	f, err := os.OpenFile(guestDevice, os.O_RDWR|os.O_SYNC, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", guestDevice, err)
+	}
+	defer f.Close()
+
+	var req reportReq
+	copy(req.ReportData[:], util.Pad(reportData, reportDataSize))
+
+	if err := ioctl.Do(int(f.Fd()), cmdGetReport0, unsafe.Pointer(&req)); err != nil {
+		return nil, fmt.Errorf("TDX_CMD_GET_REPORT0 ioctl: %w", err)
+	}
+	out := make([]byte, tdReportSize)
+	copy(out, req.TdReport[:])
+	return out, nil
+}
+
+// mrConfigID returns the 48-byte MRCONFIGID from a raw TDREPORT.
+func mrConfigID(report []byte) ([]byte, error) {
+	if len(report) < offsetMrConfigID+lenMrConfigID {
+		return nil, fmt.Errorf("tdreport too short: %d", len(report))
+	}
+	return report[offsetMrConfigID : offsetMrConfigID+lenMrConfigID], nil
+}
+
+// getRtmr returns the 48-byte RTMR value at the given index (0..3) from a raw
+// TDREPORT. Since the register is stored as little-endian u64s, the raw bytes
+// are already the desired output (matches TdReport::get_rtmr).
+func getRtmr(report []byte, rtmrIndex int) ([]byte, error) {
+	start := offsetRtmr + rtmrIndex*rtmrEntryLen
+	if rtmrIndex < 0 || len(report) < start+rtmrEntryLen {
+		return nil, fmt.Errorf("tdreport too short for rtmr %d", rtmrIndex)
+	}
+	out := make([]byte, rtmrEntryLen)
+	copy(out, report[start:start+rtmrEntryLen])
+	return out, nil
+}

--- a/attestation-agent/attester-go/platform/tdx/tdx.go
+++ b/attestation-agent/attester-go/platform/tdx/tdx.go
@@ -1,0 +1,216 @@
+// Copyright (c) 2022-2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package tdx implements the Intel TDX attester. All quote paths of the Rust
+// attester are supported natively (no libtdx_attest): ConfigFS TSM, plus
+// GET_REPORT0 + QGS over vsock or the GetQuote TDVMCALL ioctl.
+package tdx
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/confidential-containers/guest-components/attestation-agent/attester-go/api"
+	"github.com/confidential-containers/guest-components/attestation-agent/attester-go/internal/eventlog"
+	"github.com/confidential-containers/guest-components/attestation-agent/attester-go/internal/ioctl"
+	"github.com/confidential-containers/guest-components/attestation-agent/attester-go/internal/tsm"
+	"github.com/confidential-containers/guest-components/attestation-agent/attester-go/internal/util"
+)
+
+const (
+	rtmrSysfsPath = "/sys/devices/virtual/misc/tdx_guest/measurements"
+	extendDataLen = 48
+)
+
+// evidence is the TDX evidence. Field order matches the Rust TdxEvidence.
+type evidence struct {
+	Quote       string           `json:"quote"`
+	CcEventlog  *string          `json:"cc_eventlog"`
+	GpuEvidence *GpuEvidenceList `json:"gpu_evidence"`
+}
+
+// Attester collects Intel TDX evidence.
+type Attester struct {
+	api.Base
+}
+
+// New creates a TDX Attester.
+func New() *Attester { return &Attester{} }
+
+// DetectPlatform reports whether the guest is a TDX guest.
+func DetectPlatform() bool {
+	return tsm.Available() || util.FileExists(guestDevice)
+}
+
+func (a *Attester) GetEvidence(reportData []byte) (api.TeeEvidence, error) {
+	if len(reportData) > reportDataSize {
+		return nil, fmt.Errorf("TDX attester: report data must be <= %d bytes", reportDataSize)
+	}
+	rd := util.Pad(reportData, reportDataSize)
+
+	quoteBytes, err := a.getQuote(rd)
+	if err != nil {
+		return nil, err
+	}
+
+	ccEventlog, err := eventlog.Read()
+	if err != nil {
+		return nil, err
+	}
+
+	// GPU evidence is best-effort (nil when unsupported / not built with -tags gpu).
+	gpuEvidence := collectGpuEvidence(rd)
+
+	ev := evidence{
+		Quote:       base64.StdEncoding.EncodeToString(quoteBytes),
+		CcEventlog:  ccEventlog,
+		GpuEvidence: gpuEvidence,
+	}
+	return json.Marshal(ev)
+}
+
+// getQuote produces a TD quote. Primary path is ConfigFS TSM (no external lib);
+// when TSM is unavailable it falls back to the DCAP-equivalent path (GET_REPORT0
+// ioctl + QGS message over vsock or the GetQuote TDVMCALL ioctl). This mirrors
+// the Rust attester (TSM primary, tdx_att_get_quote fallback).
+func (a *Attester) getQuote(reportData []byte) ([]byte, error) {
+	if tsm.Available() {
+		return tsm.GetReport(tsm.ProviderTdx, reportData, -1)
+	}
+	return getQuoteViaQgs(reportData)
+}
+
+// getQuoteViaQgs reimplements tdx_att_get_quote without libtdx_attest: it reads
+// the TDREPORT via ioctl, builds a QGS request, and tries the vsock transport
+// then the GetQuote TDVMCALL ioctl (transport order matches DCAP).
+func getQuoteViaQgs(reportData []byte) ([]byte, error) {
+	tdreport, err := getTdReport(reportData)
+	if err != nil {
+		return nil, err
+	}
+	qgsReq := buildGetQuoteReq(tdreport)
+
+	// vsock first (only when /etc/tdx-attest.conf configures a port).
+	resp, err := vsockGetQuote(qgsReq)
+	if err == nil {
+		return parseGetQuoteResp(resp)
+	}
+	if !errors.Is(err, errTransportUnsupported) {
+		// A configured vsock that fails is a hard error, matching DCAP.
+		return nil, err
+	}
+
+	// GetQuote TDVMCALL ioctl.
+	resp, err = tdcallGetQuote(qgsReq)
+	if err != nil {
+		return nil, err
+	}
+	return parseGetQuoteResp(resp)
+}
+
+func (a *Attester) BindInitData(initDataDigest []byte) (api.InitDataResult, error) {
+	report, err := getTdReport(make([]byte, reportDataSize))
+	if err != nil {
+		return api.InitDataUnsupported, err
+	}
+	mrConfig, err := mrConfigID(report)
+	if err != nil {
+		return api.InitDataUnsupported, err
+	}
+	if !bytes.Equal(util.Pad(initDataDigest, 48), mrConfig) {
+		return api.InitDataUnsupported, errors.New("TDX attester: init data does not match")
+	}
+	return api.InitDataOk, nil
+}
+
+func (a *Attester) GetRuntimeMeasurement(pcrIndex uint64) ([]byte, error) {
+	report, err := getTdReport(make([]byte, reportDataSize))
+	if err != nil {
+		return nil, err
+	}
+	ccmr := a.PcrToCcmr(pcrIndex)
+	return getRtmr(report, int(ccmr)-1)
+}
+
+func (a *Attester) ExtendRuntimeMeasurement(eventDigest []byte, registerIndex uint64) error {
+	if !util.FileExists(guestDevice) && !util.FileExists(rtmrSysfsPath) {
+		return errors.New("TDX attester: runtime measurement extend is not available")
+	}
+	ccmr := a.PcrToCcmr(registerIndex)
+	rtmrIndex := ccmr - 1
+	extendData := util.Pad(eventDigest, extendDataLen)
+
+	// sysfs first, ioctl fallback (matches DCAP tdx_att_extend).
+	if err := extendRtmrViaSysfs(rtmrIndex, extendData); err != nil {
+		log.Printf("TDX attester: sysfs RTMR extend failed (%v), trying ioctl", err)
+		if err2 := extendRtmrViaIoctl(rtmrIndex, extendData); err2 != nil {
+			return fmt.Errorf("TDX attester: extend RTMR failed: sysfs=%v ioctl=%v", err, err2)
+		}
+	}
+	return nil
+}
+
+func extendRtmrViaSysfs(rtmrIndex uint64, extendData []byte) error {
+	p := filepath.Join(rtmrSysfsPath, fmt.Sprintf("rtmr%d:sha384", rtmrIndex))
+	return os.WriteFile(p, extendData, 0o644)
+}
+
+// extendRtmrReq mirrors `struct tdx_extend_rtmr_req { __u8 data[48]; __u8 index; }`.
+type extendRtmrReq struct {
+	Data  [extendDataLen]byte
+	Index uint8
+}
+
+var cmdExtendRtmrVariants = []uintptr{
+	ioctl.IOW('T', 3, unsafe.Sizeof(extendRtmrReq{})),
+	ioctl.IOR('T', 3, unsafe.Sizeof(extendRtmrReq{})),
+}
+
+func extendRtmrViaIoctl(rtmrIndex uint64, extendData []byte) error {
+	f, err := os.OpenFile(guestDevice, os.O_RDWR|os.O_SYNC, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	var req extendRtmrReq
+	copy(req.Data[:], extendData)
+	req.Index = uint8(rtmrIndex)
+
+	var ioErr error
+	for _, r := range cmdExtendRtmrVariants {
+		ioErr = ioctl.Do(int(f.Fd()), r, unsafe.Pointer(&req))
+		if errors.Is(ioErr, unix.ENOTTY) {
+			continue
+		}
+		return ioErr
+	}
+	return ioErr
+}
+
+// PcrToCcmr maps a PCR index to a TDX CC measurement register, per td-shim /
+// UEFI CC spec.
+func (a *Attester) PcrToCcmr(pcrIndex uint64) uint64 {
+	switch {
+	case pcrIndex == 1 || pcrIndex == 7:
+		return 1
+	case pcrIndex >= 2 && pcrIndex <= 6:
+		return 2
+	case pcrIndex >= 8 && pcrIndex <= 15:
+		return 3
+	default:
+		return 4
+	}
+}
+
+func (a *Attester) CcelHashAlgorithm() api.HashAlgorithm { return api.HashSha384 }


### PR DESCRIPTION
## What

Adds `attestation-agent/attester-go`, a pure-Go re-implementation of the `attester` crate. It collects TEE attestation evidence from a confidential guest and produces evidence whose JSON is **byte-compatible with the Rust attester**, so it verifies against an unmodified Trustee `attestation-service`.

## Why

To let Go programs collect TEE evidence with **no cgo and no external shared library** — in particular without `libtdx_attest.so`/DCAP. Every platform is driven through native kernel interfaces (ConfigFS TSM, ioctl on `/dev/tdx_guest`, `/dev/sev-guest`, `/dev/csv-guest`, vsock). The default build (`CGO_ENABLED=0`) is a fully static binary with zero platform `.so` dependencies, so one binary runs across heterogeneous TEE hosts and undetected platforms are simply skipped.

## Platforms

- **sample** — software measurement register + event log.
- **TDX** — all quote paths of the Rust attester, natively:
  1. ConfigFS TSM (`/sys/kernel/config/tsm/report`), primary;
  2. `GET_REPORT0` + QGS message over vsock (when `/etc/tdx-attest.conf` sets a port);
  3. `TDX_CMD_GET_QUOTE` TDVMCALL ioctl (what `libtdx_attest` does internally, reimplemented without the library).
  Plus `GET_REPORT0` for `BindInitData`/`GetRuntimeMeasurement` and RTMR extend (sysfs + `TDX_CMD_EXTEND_RTMR` ioctl).
- **SNP** — `/dev/sev-guest` `SNP_GET_EXT_REPORT` (report + cert chain).
- **CSV** — `/dev/csv-guest` `CSV_GET_REPORT` with a self-contained SM3, PEK/serial extraction, optional HSK/CEK download from the Hygon KDS.
- **GPU evidence** (optional, `-tags gpu`) — NVIDIA NVML via go-nvml, which `dlopen`s `libnvidia-ml` at runtime (no hard dependency; the binary still starts without a driver).

## Evidence compatibility

The evidence structs reproduce `serde_json`'s exact output of the Rust types: fixed `[u8; N]` render as number arrays (`[N]byte`, never base64), `Vec<u8>` fields that must be number arrays use a custom marshaler, newtype wrappers render as bare numbers, SNP `cert_type` as bare string / `{"OTHER":...}`, and `Option` fields keep the exact `null`/omitted behaviour.

## Testing

- **TDX**: validated end-to-end on real Intel TDX hardware — the `GET_QUOTE` TDVMCALL ioctl path produces a valid quote, and both the input `report_data` and the RTMRs read via `GET_REPORT0` are verified to be embedded in the produced quote.
- **sample**: unit-tested.
- **SNP/CSV**: struct sizes and JSON byte-format are locked by unit tests; the ioctl collection paths follow the `sev` 4.0.0 and `csv-rs` ABIs but have not yet been exercised on real SNP/CSV hardware.

## Notes

- New self-contained Go module under `attestation-agent/attester-go`; does not touch the existing Rust crates.
- Default build depends only on `golang.org/x/sys`; `go-nvml` is pulled in only under `-tags gpu`.
