### PR TITLE
feat(agent): add pure-Go attestation-agent library (agent-go)

### DIFF
--- a/attestation-agent/agent-go/README.md
+++ b/attestation-agent/agent-go/README.md
@@ -1,0 +1,72 @@
+# agent-go
+
+`agent-go` is a pure-Go re-implementation of the guest-components
+`attestation-agent` **library crate**
+(`attestation-agent/attestation-agent`). It sits on top of
+[`attester-go`](../attester-go) and exposes the attestation-agent service API to
+Go programs, with no cgo and no external shared library.
+
+## What it provides
+
+The `AttestationAPIs` interface mirrors the Rust `AttestationAPIs` trait:
+
+| Method | Description |
+| --- | --- |
+| `GetEvidence(runtimeData)` | TEE hardware-signed evidence (compact JSON) for the given runtime/report data. |
+| `GetAdditionalEvidence(runtimeData)` | Evidence from additional (device) attesters; empty when none. |
+| `GetToken(tokenType, additionalData)` | Attestation token from a remote service (`coco_as`). |
+| `ExtendRuntimeMeasurement(domain, operation, content, registerIndex)` | Extend a runtime measurement register **and** record the event in the AA Event Log (AAEL). |
+| `BindInitData(initData)` | Bind an init-data digest to the TEE. |
+| `GetTeeType()` / `GetAdditionalTees()` | The detected primary / additional TEE types. |
+
+Supporting packages, one per Rust module:
+
+- `config` — parse the AA config (TOML or JSON) with the same defaults, plus
+  `aa_kbc_params` resolution from the environment / kernel command line.
+- `eventlog` — the AAEL: TCG2 event encoding, extend-into-register, and a
+  write-ahead log (WAL) that makes the "extend register + append log" pair
+  crash-recoverable. The TCG2 event-data digest is byte-compatible with the Rust
+  implementation (locked by unit-test vectors).
+- `initdata` — parse the Initdata TOML and compute its digest.
+- `token` — obtain an attestation token (CoCoAS).
+
+## Usage
+
+```go
+import "github.com/confidential-containers/guest-components/attestation-agent/agent-go"
+
+aa, err := attestationagent.New(nil) // or .New(&path) to load a config file
+if err != nil { /* ... */ }
+if err := aa.Init(); err != nil {    // enables the event log if configured
+    /* ... */
+}
+
+evidence, err := aa.GetEvidence([]byte("nonce"))
+```
+
+## Differences from the Rust crate
+
+All of these follow the scope already established by `attester-go`:
+
+- **No cgo / no shared library.** Every platform is reached through
+  `attester-go`'s native kernel interfaces. The default build is
+  `CGO_ENABLED=0`.
+- **`instance_info` is not ported** (AA instance info / heartbeat). An
+  `[aa_instance]` section in an existing config file is ignored.
+- **KBS token is not ported.** Obtaining a KBS token needs the KBS
+  background-check protocol (the Rust `kbs_protocol` crate: RCAR handshake + TEE
+  key pair), which has no Go port yet; `token.KbsTokenGetter.GetToken` returns
+  `token.ErrKbsNotImplemented`. The **CoCoAS** token is fully implemented.
+- **No additional (device) attesters.** `attester-go` exposes none, so
+  `GetAdditionalEvidence` returns empty and `GetAdditionalTees` is empty.
+
+## Testing
+
+```
+go test ./...
+```
+
+Unit tests cover the TCG2 digest vectors (byte-compatibility with the Rust
+attestation-agent), the event-log extend + WAL crash-recovery paths (with an
+in-memory attester), config TOML/JSON parsing and defaults, `aa_kbc_params`,
+Initdata digest, token dispatch and CoCoAS URL resolution.

--- a/attestation-agent/agent-go/agent.go
+++ b/attestation-agent/agent-go/agent.go
@@ -1,0 +1,272 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package attestationagent is a pure-Go re-implementation of the guest-components
+// `attestation-agent` library crate (attestation-agent/attestation-agent). It
+// provides the attestation procedures used by confidential containers on top of
+// the pure-Go attester-go module:
+//
+//   - GetToken: obtain an attestation token from a remote service (CoCoAS).
+//   - GetEvidence: obtain TEE hardware-signed evidence for given runtime data.
+//   - ExtendRuntimeMeasurement: extend a runtime measurement register and record
+//     the event in the AA Event Log (AAEL).
+//   - BindInitData: bind an init-data digest to the TEE.
+//
+// Differences from the Rust crate, all following the scope already established
+// by attester-go:
+//
+//   - No cgo and no external shared library: every platform is reached through
+//     attester-go's native kernel interfaces.
+//   - The `instance_info` feature (AA instance info / heartbeat) is not ported.
+//   - KBS token support is not ported (it needs a Go port of kbs_protocol); the
+//     CoCoAS token is fully implemented. See package token.
+//   - attester-go exposes no additional (device) attesters, so
+//     GetAdditionalEvidence always returns empty and GetAdditionalTees is empty.
+package attestationagent
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	attester "github.com/confidential-containers/guest-components/attestation-agent/attester-go"
+
+	"github.com/confidential-containers/guest-components/attestation-agent/agent-go/config"
+	"github.com/confidential-containers/guest-components/attestation-agent/agent-go/eventlog"
+	"github.com/confidential-containers/guest-components/attestation-agent/agent-go/token"
+)
+
+// Re-exported attester types for convenience.
+type (
+	// Tee identifies the confidential computing platform.
+	Tee = attester.Tee
+	// InitDataResult is the outcome of BindInitData.
+	InitDataResult = attester.InitDataResult
+	// Config is the AA configuration.
+	Config = config.Config
+)
+
+// AttestationAPIs is the service API surface of the attestation agent,
+// mirroring the Rust `AttestationAPIs` trait.
+type AttestationAPIs interface {
+	// GetToken obtains an attestation token of the given type. additionalData
+	// is forwarded to the CoCoAS token getter (pass nil for none).
+	GetToken(tokenType string, additionalData *string) ([]byte, error)
+
+	// GetEvidence returns TEE hardware-signed evidence that includes
+	// runtimeData, as compact JSON bytes.
+	GetEvidence(runtimeData []byte) ([]byte, error)
+
+	// GetAdditionalEvidence returns evidence from all additional attesters. It
+	// returns an empty slice when none are configured.
+	GetAdditionalEvidence(runtimeData []byte) ([]byte, error)
+
+	// ExtendRuntimeMeasurement extends a runtime measurement register with the
+	// event (domain, operation, content) and records it in the AAEL.
+	// registerIndex selects the target register; pass nil for the configured
+	// default.
+	ExtendRuntimeMeasurement(domain, operation, content string, registerIndex *uint64) error
+
+	// BindInitData binds an init-data digest to the current TEE.
+	BindInitData(initData []byte) (InitDataResult, error)
+
+	// GetTeeType returns the detected primary TEE type.
+	GetTeeType() Tee
+
+	// GetAdditionalTees returns the additional (device) TEE types.
+	GetAdditionalTees() []Tee
+}
+
+// AttestationAgent provides the attestation service. Create it with New and,
+// before extending runtime measurements, call Init.
+type AttestationAgent struct {
+	primaryTee Tee
+
+	configMu sync.RWMutex
+	config   *config.Config
+
+	eventlogMu sync.Mutex
+	eventlog   *eventlog.EventLog
+
+	initdata *string
+
+	primaryAttester     attester.Attester
+	additionalAttesters map[Tee]attester.Attester
+}
+
+// Compile-time assertion that AttestationAgent satisfies AttestationAPIs.
+var _ AttestationAPIs = (*AttestationAgent)(nil)
+
+// New creates an AttestationAgent. If configPath is nil, a default
+// configuration is used; otherwise the file (TOML or JSON) is loaded. Mirrors
+// Rust AttestationAgent::new.
+func New(configPath *string) (*AttestationAgent, error) {
+	var cfg *config.Config
+	var err error
+	if configPath != nil {
+		if cfg, err = config.Load(*configPath); err != nil {
+			return nil, err
+		}
+	} else {
+		if cfg, err = config.New(); err != nil {
+			return nil, err
+		}
+	}
+
+	primaryTee := attester.DetectTeeType()
+	primaryAttester, err := attester.New(primaryTee)
+	if err != nil {
+		return nil, err
+	}
+
+	// attester-go exposes no additional (device) attesters; the map stays empty.
+	return &AttestationAgent{
+		primaryTee:          primaryTee,
+		config:              cfg,
+		primaryAttester:     primaryAttester,
+		additionalAttesters: map[Tee]attester.Attester{},
+	}, nil
+}
+
+// Init initializes the event log if it is enabled in the configuration.
+// Mirrors Rust AttestationAgent::init (minus the dropped instance_info setup).
+func (a *AttestationAgent) Init() error {
+	a.configMu.RLock()
+	enable := a.config.EventlogConfig.EnableEventlog
+	initPCR := a.config.EventlogConfig.InitPcr
+	a.configMu.RUnlock()
+
+	if !enable {
+		return nil
+	}
+
+	el, err := eventlog.New(a.primaryAttester, initPCR)
+	if err != nil {
+		return err
+	}
+	a.eventlogMu.Lock()
+	a.eventlog = el
+	a.eventlogMu.Unlock()
+	return nil
+}
+
+// SetInitdataToml records the init-data TOML as the state of this AA instance,
+// mirroring Rust set_initdata_toml.
+func (a *AttestationAgent) SetInitdataToml(initdataToml string) {
+	a.initdata = &initdataToml
+}
+
+// Config returns the current configuration (read-locked copy of the pointer).
+func (a *AttestationAgent) Config() *config.Config {
+	a.configMu.RLock()
+	defer a.configMu.RUnlock()
+	return a.config
+}
+
+// GetToken implements AttestationAPIs.
+func (a *AttestationAgent) GetToken(tokenType string, additionalData *string) ([]byte, error) {
+	tt, err := token.ParseTokenType(tokenType)
+	if err != nil {
+		return nil, fmt.Errorf("Unsupported token type: %w", err)
+	}
+
+	a.configMu.RLock()
+	tokenConfigs := a.config.TokenConfigs
+	initdata := a.initdata
+	a.configMu.RUnlock()
+
+	switch tt {
+	case token.TokenTypeKbs:
+		if tokenConfigs.Kbs == nil {
+			return nil, fmt.Errorf("kbs token config not configured in config file")
+		}
+		return token.NewKbs(tokenConfigs.Kbs).GetToken(initdata)
+	case token.TokenTypeCoCoAS:
+		if tokenConfigs.CoCoAS == nil {
+			return nil, fmt.Errorf("coco_as token config not configured in config file")
+		}
+		return token.NewCoCoAS(tokenConfigs.CoCoAS).GetToken(additionalData)
+	default:
+		return nil, fmt.Errorf("Unsupported token type: %s", tokenType)
+	}
+}
+
+// GetEvidence implements AttestationAPIs.
+func (a *AttestationAgent) GetEvidence(runtimeData []byte) ([]byte, error) {
+	evidence, err := a.primaryAttester.GetEvidence(runtimeData)
+	if err != nil {
+		return nil, err
+	}
+	// evidence is already compact JSON, matching the Rust
+	// evidence.to_string().into_bytes().
+	return []byte(evidence), nil
+}
+
+// GetAdditionalEvidence implements AttestationAPIs.
+func (a *AttestationAgent) GetAdditionalEvidence(runtimeData []byte) ([]byte, error) {
+	if len(a.additionalAttesters) == 0 {
+		// No additional attesters configured, return empty evidence.
+		return []byte{}, nil
+	}
+
+	evidence := make(map[Tee]json.RawMessage, len(a.additionalAttesters))
+	for tee, att := range a.additionalAttesters {
+		ev, err := att.GetEvidence(runtimeData)
+		if err != nil {
+			return nil, err
+		}
+		evidence[tee] = json.RawMessage(ev)
+	}
+	out, err := json.Marshal(evidence)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to serialize additional evidence: %w", err)
+	}
+	return out, nil
+}
+
+// ExtendRuntimeMeasurement implements AttestationAPIs.
+func (a *AttestationAgent) ExtendRuntimeMeasurement(domain, operation, content string, registerIndex *uint64) error {
+	a.eventlogMu.Lock()
+	defer a.eventlogMu.Unlock()
+
+	if a.eventlog == nil {
+		return fmt.Errorf("Extend eventlog not enabled when launching!")
+	}
+
+	pcr := a.defaultPCR()
+	if registerIndex != nil {
+		pcr = *registerIndex
+	}
+
+	event, err := eventlog.NewEvent(domain, operation, content)
+	if err != nil {
+		return err
+	}
+	return a.eventlog.ExtendEntry(event, pcr)
+}
+
+func (a *AttestationAgent) defaultPCR() uint64 {
+	a.configMu.RLock()
+	defer a.configMu.RUnlock()
+	return a.config.EventlogConfig.InitPcr
+}
+
+// BindInitData implements AttestationAPIs.
+func (a *AttestationAgent) BindInitData(initData []byte) (InitDataResult, error) {
+	return a.primaryAttester.BindInitData(initData)
+}
+
+// GetTeeType implements AttestationAPIs.
+func (a *AttestationAgent) GetTeeType() Tee {
+	return a.primaryTee
+}
+
+// GetAdditionalTees implements AttestationAPIs.
+func (a *AttestationAgent) GetAdditionalTees() []Tee {
+	tees := make([]Tee, 0, len(a.additionalAttesters))
+	for tee := range a.additionalAttesters {
+		tees = append(tees, tee)
+	}
+	return tees
+}

--- a/attestation-agent/agent-go/agent_test.go
+++ b/attestation-agent/agent-go/agent_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package attestationagent
+
+import (
+	"testing"
+
+	attester "github.com/confidential-containers/guest-components/attestation-agent/attester-go"
+)
+
+// TestAttestationAgent mirrors the Rust test_attestation_agent: on a
+// non-confidential host the sample attester is used, evidence and init-data
+// binding succeed, token retrieval fails, and extending a measurement fails
+// because the event log is not enabled.
+func TestAttestationAgent(t *testing.T) {
+	aa, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if aa.GetTeeType() != attester.TeeSample {
+		t.Errorf("tee type = %q, want sample", aa.GetTeeType())
+	}
+
+	// No token config for coco_as, and KBS is not implemented: both fail.
+	if _, err := aa.GetToken("coco_as", nil); err == nil {
+		t.Error("expected GetToken(coco_as) to fail without config")
+	}
+	if _, err := aa.GetToken("kbs", nil); err == nil {
+		t.Error("expected GetToken(kbs) to fail")
+	}
+
+	if _, err := aa.GetEvidence(nil); err != nil {
+		t.Errorf("GetEvidence: unexpected error %v", err)
+	}
+
+	if _, err := aa.BindInitData(nil); err != nil {
+		t.Errorf("BindInitData: unexpected error %v", err)
+	}
+
+	// Event log not enabled -> extend must fail.
+	if err := aa.ExtendRuntimeMeasurement("domain", "operation", "content", nil); err == nil {
+		t.Error("expected ExtendRuntimeMeasurement to fail when event log disabled")
+	}
+}
+
+func TestGetAdditionalEvidenceEmpty(t *testing.T) {
+	aa, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ev, err := aa.GetAdditionalEvidence(nil)
+	if err != nil {
+		t.Fatalf("GetAdditionalEvidence: %v", err)
+	}
+	if len(ev) != 0 {
+		t.Errorf("expected empty additional evidence, got %q", string(ev))
+	}
+	if tees := aa.GetAdditionalTees(); len(tees) != 0 {
+		t.Errorf("expected no additional tees, got %v", tees)
+	}
+}

--- a/attestation-agent/agent-go/config/aakbcparams.go
+++ b/attestation-agent/agent-go/config/aakbcparams.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// AaKbcParams mirrors the Rust aa_kbc_params: the `kbc::uri` pair sourced from
+// the AA_KBC_PARAMS environment variable or the kernel command line.
+type AaKbcParams struct {
+	Kbc string
+	Uri string
+}
+
+// DefaultAaKbcParams is used when neither the environment variable nor the
+// kernel command line provides a value.
+func DefaultAaKbcParams() AaKbcParams {
+	return AaKbcParams{Kbc: "offline_fs_kbc", Uri: ""}
+}
+
+// NewAaKbcParams resolves the aa_kbc_params, falling back to the default when
+// no value is found. Mirrors Rust AaKbcParams::new.
+func NewAaKbcParams() (AaKbcParams, error) {
+	value, err := aaKbcParamsValue()
+	if err != nil {
+		// failed to get from either env or kernel cmdline: use default.
+		return DefaultAaKbcParams(), nil
+	}
+	return parseAaKbcParams(value)
+}
+
+func aaKbcParamsValue() (string, error) {
+	if params, ok := os.LookupEnv("AA_KBC_PARAMS"); ok {
+		return params, nil
+	}
+	return aaKbcParamsFromCmdline()
+}
+
+func aaKbcParamsFromCmdline() (string, error) {
+	cmdline, err := os.ReadFile("/proc/cmdline")
+	if err != nil {
+		return "", err
+	}
+	const prefix = "agent.aa_kbc_params="
+	for _, field := range strings.Fields(string(cmdline)) {
+		if v, ok := strings.CutPrefix(field, prefix); ok {
+			return v, nil
+		}
+	}
+	return "", fmt.Errorf("no `agent.aa_kbc_params` provided in kernel commandline")
+}
+
+func parseAaKbcParams(value string) (AaKbcParams, error) {
+	segments := strings.Split(value, "::")
+	if len(segments) != 2 {
+		return AaKbcParams{}, fmt.Errorf("illegal aa_kbc_params format: %s", value)
+	}
+	return AaKbcParams{Kbc: segments[0], Uri: segments[1]}, nil
+}

--- a/attestation-agent/agent-go/config/aakbcparams_test.go
+++ b/attestation-agent/agent-go/config/aakbcparams_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// TestNewAaKbcParamsDefault verifies the fallback: with no AA_KBC_PARAMS
+// environment variable and no `agent.aa_kbc_params` on the kernel command line
+// (the case in the test environment), the default is returned.
+func TestNewAaKbcParamsDefault(t *testing.T) {
+	orig, had := os.LookupEnv("AA_KBC_PARAMS")
+	os.Unsetenv("AA_KBC_PARAMS")
+	t.Cleanup(func() {
+		if had {
+			os.Setenv("AA_KBC_PARAMS", orig)
+		}
+	})
+
+	params, err := NewAaKbcParams()
+	if err != nil {
+		t.Skipf("kernel command line provides aa_kbc_params in this environment: %v", err)
+	}
+	if params.Kbc != "offline_fs_kbc" || params.Uri != "" {
+		t.Errorf("params = %+v, want default {offline_fs_kbc }", params)
+	}
+}
+
+func TestParseAaKbcParams(t *testing.T) {
+	p, err := parseAaKbcParams("cc_kbc::http://127.0.0.1:8080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Kbc != "cc_kbc" || p.Uri != "http://127.0.0.1:8080" {
+		t.Errorf("params = %+v", p)
+	}
+
+	if _, err := parseAaKbcParams("not-a-pair"); err == nil {
+		t.Error("expected error for malformed params")
+	}
+}
+
+func TestNewAaKbcParamsFromEnv(t *testing.T) {
+	t.Setenv("AA_KBC_PARAMS", "cc_kbc::https://kbs.example.com")
+	p, err := NewAaKbcParams()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Kbc != "cc_kbc" || p.Uri != "https://kbs.example.com" {
+		t.Errorf("params = %+v", p)
+	}
+}

--- a/attestation-agent/agent-go/config/config.go
+++ b/attestation-agent/agent-go/config/config.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package config is a pure-Go re-implementation of the attestation-agent crate
+// `config` module. It parses the AA configuration (TOML or JSON) and provides
+// the same defaults, so an existing attestation-agent.conf works unchanged.
+//
+// Note: the `instance_info` feature (aa_instance / heartbeat) is intentionally
+// not ported. An `[aa_instance]` section in an existing config file is ignored.
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+)
+
+// DefaultPcrIndex is the default PCR index used by AA (17, the dynamic root of
+// trust for measurement register).
+const DefaultPcrIndex uint64 = 17
+
+// DefaultAAConfigPath is the default on-disk location of the AA config file.
+const DefaultAAConfigPath = "/etc/attestation-agent.conf"
+
+// Config is the top-level AA configuration.
+type Config struct {
+	// TokenConfigs holds attestation-token related configuration.
+	TokenConfigs TokenConfigs `toml:"token_configs" json:"token_configs"`
+
+	// EventlogConfig holds event-log related configuration.
+	EventlogConfig EventlogConfig `toml:"eventlog_config" json:"eventlog_config"`
+}
+
+// TokenConfigs groups the per-token-type configuration.
+type TokenConfigs struct {
+	// CoCoAS is the CoCo Attestation Service token configuration.
+	CoCoAS *CoCoASConfig `toml:"coco_as" json:"coco_as"`
+
+	// Kbs is the Key Broker Service token configuration.
+	Kbs *KbsConfig `toml:"kbs" json:"kbs"`
+}
+
+// CoCoASConfig configures the CoCoAS token getter.
+type CoCoASConfig struct {
+	// URL is the address of the Attestation Service.
+	URL string `toml:"url" json:"url"`
+}
+
+// KbsConfig configures the KBS token getter.
+type KbsConfig struct {
+	// URL is the address of the KBS.
+	URL string `toml:"url" json:"url"`
+
+	// Cert is the optional KBS HTTPS certificate (PEM).
+	Cert *string `toml:"cert" json:"cert"`
+}
+
+// EventlogConfig configures the runtime-measurement event log.
+type EventlogConfig struct {
+	// InitPcr is the PCR register used to extend event-log entries.
+	InitPcr uint64 `toml:"init_pcr" json:"init_pcr"`
+
+	// EnableEventlog toggles event-log recording.
+	EnableEventlog bool `toml:"enable_eventlog" json:"enable_eventlog"`
+}
+
+// DefaultEventlogConfig mirrors the Rust EventlogConfig::default.
+func DefaultEventlogConfig() EventlogConfig {
+	return EventlogConfig{InitPcr: DefaultPcrIndex, EnableEventlog: false}
+}
+
+// New builds a default configuration, sourcing the KBS token config from the
+// kernel command line, mirroring Rust Config::new.
+func New() (*Config, error) {
+	return &Config{
+		TokenConfigs:   tokenConfigsFromKernelCmdline(),
+		EventlogConfig: DefaultEventlogConfig(),
+	}, nil
+}
+
+// tokenConfigsFromKernelCmdline mirrors TokenConfigs::from_kernel_cmdline: the
+// KBS URL comes from aa_kbc_params, CoCoAS is left unset.
+func tokenConfigsFromKernelCmdline() TokenConfigs {
+	var kbs *KbsConfig
+	if params, err := NewAaKbcParams(); err == nil {
+		kbs = &KbsConfig{URL: params.Uri, Cert: nil}
+	}
+	return TokenConfigs{Kbs: kbs}
+}
+
+// Load parses the configuration file at path (TOML or JSON, detected by
+// extension). Missing event-log fields fall back to the defaults, mirroring the
+// Rust `config` builder defaults.
+func Load(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read config file %q: %w", path, err)
+	}
+
+	// Pre-populate event-log defaults so absent keys keep the default value,
+	// matching the Rust builder's set_default calls.
+	cfg := Config{EventlogConfig: DefaultEventlogConfig()}
+
+	if filepath.Ext(path) == ".json" {
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return nil, fmt.Errorf("parse json config %q: %w", path, err)
+		}
+	} else {
+		if err := toml.Unmarshal(data, &cfg); err != nil {
+			return nil, fmt.Errorf("parse toml config %q: %w", path, err)
+		}
+	}
+
+	return &cfg, nil
+}

--- a/attestation-agent/agent-go/config/config_test.go
+++ b/attestation-agent/agent-go/config/config_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTemp(t *testing.T, name, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestLoadTOML(t *testing.T) {
+	const cfg = `
+[token_configs.coco_as]
+url = "http://127.0.0.1:8000"
+
+[token_configs.kbs]
+url = "https://127.0.0.1:8080"
+cert = "cert"
+
+[eventlog_config]
+init_pcr = 17
+enable_eventlog = false
+`
+	c, err := Load(writeTemp(t, "config.toml", cfg))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.TokenConfigs.CoCoAS == nil || c.TokenConfigs.CoCoAS.URL != "http://127.0.0.1:8000" {
+		t.Errorf("coco_as = %+v", c.TokenConfigs.CoCoAS)
+	}
+	if c.TokenConfigs.Kbs == nil || c.TokenConfigs.Kbs.URL != "https://127.0.0.1:8080" {
+		t.Errorf("kbs = %+v", c.TokenConfigs.Kbs)
+	}
+	if c.TokenConfigs.Kbs.Cert == nil || *c.TokenConfigs.Kbs.Cert != "cert" {
+		t.Errorf("kbs cert = %v", c.TokenConfigs.Kbs.Cert)
+	}
+	if c.EventlogConfig.InitPcr != 17 || c.EventlogConfig.EnableEventlog {
+		t.Errorf("eventlog = %+v", c.EventlogConfig)
+	}
+}
+
+func TestLoadJSON(t *testing.T) {
+	const cfg = `{
+  "token_configs": { "coco_as": { "url": "http://127.0.0.1:8000" } },
+  "eventlog_config": { "init_pcr": 19, "enable_eventlog": true }
+}`
+	c, err := Load(writeTemp(t, "config.json", cfg))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.TokenConfigs.CoCoAS == nil || c.TokenConfigs.CoCoAS.URL != "http://127.0.0.1:8000" {
+		t.Errorf("coco_as = %+v", c.TokenConfigs.CoCoAS)
+	}
+	if c.TokenConfigs.Kbs != nil {
+		t.Errorf("kbs should be nil, got %+v", c.TokenConfigs.Kbs)
+	}
+	if c.EventlogConfig.InitPcr != 19 || !c.EventlogConfig.EnableEventlog {
+		t.Errorf("eventlog = %+v", c.EventlogConfig)
+	}
+}
+
+// TestLoadDefaultsApplied checks that a config file omitting the event-log
+// section still gets the defaults (17, false), mirroring the Rust builder.
+func TestLoadDefaultsApplied(t *testing.T) {
+	const cfg = `
+[token_configs.kbs]
+url = "https://127.0.0.1:8080"
+`
+	c, err := Load(writeTemp(t, "config.toml", cfg))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.EventlogConfig.InitPcr != DefaultPcrIndex || c.EventlogConfig.EnableEventlog {
+		t.Errorf("expected defaults, got %+v", c.EventlogConfig)
+	}
+	if c.TokenConfigs.Kbs.Cert != nil {
+		t.Errorf("expected nil cert, got %v", c.TokenConfigs.Kbs.Cert)
+	}
+}
+
+func TestNewDefaults(t *testing.T) {
+	c, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if c.EventlogConfig.InitPcr != DefaultPcrIndex {
+		t.Errorf("init_pcr = %d, want %d", c.EventlogConfig.InitPcr, DefaultPcrIndex)
+	}
+	if c.EventlogConfig.EnableEventlog {
+		t.Error("enable_eventlog should default to false")
+	}
+}

--- a/attestation-agent/agent-go/eventlog/eventlog.go
+++ b/attestation-agent/agent-go/eventlog/eventlog.go
@@ -1,0 +1,277 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package eventlog is a pure-Go re-implementation of the attestation-agent
+// crate `eventlog` module. It maintains the AA Event Log (AAEL): each entry is
+// written as a TCG2 event and, atomically, extended into a TEE runtime
+// measurement register through the attester. A write-ahead log (WAL) makes the
+// "extend register + append log" pair crash-recoverable.
+package eventlog
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/confidential-containers/guest-components/attestation-agent/agent-go/internal/hashalg"
+	attester "github.com/confidential-containers/guest-components/attestation-agent/attester-go"
+)
+
+// Filesystem locations of the AA event log and its WAL cache.
+const (
+	// ParentDir is the directory holding the AA event log.
+	ParentDir = "/run/attestation-agent"
+	// Path is the AA event log file.
+	Path = ParentDir + "/eventlog"
+	// WalCachePath caches a pending entry before it is committed.
+	WalCachePath = ParentDir + "/.wal_event_entry"
+)
+
+// Effective filesystem locations, defaulting to the exported constants. They
+// are package variables (not consts) so tests can redirect the event log to a
+// temporary directory.
+var (
+	parentDir    = ParentDir
+	logPath      = Path
+	walCachePath = WalCachePath
+)
+
+// writer abstracts the append-only backing store, matching the Rust Writer
+// trait. It is unexported; production code uses fileWriter.
+type writer interface {
+	write(data []byte) error
+	seek(pos uint64) error
+	currentPos() uint64
+}
+
+type fileWriter struct {
+	file *os.File
+	pos  uint64
+}
+
+func (w *fileWriter) write(data []byte) error {
+	n, err := w.file.Write(data)
+	if err != nil {
+		return fmt.Errorf("failed to write log: %w", err)
+	}
+	if err := w.file.Sync(); err != nil {
+		return fmt.Errorf("failed to flush log to I/O media: %w", err)
+	}
+	w.pos += uint64(n)
+	return nil
+}
+
+func (w *fileWriter) seek(pos uint64) error {
+	if _, err := w.file.Seek(int64(pos), io.SeekStart); err != nil {
+		return fmt.Errorf("failed to seek log: %w", err)
+	}
+	w.pos = pos
+	return nil
+}
+
+func (w *fileWriter) currentPos() uint64 { return w.pos }
+
+// walCache is the write-ahead log record.
+type walCache struct {
+	// expectedPCR is the target register value after the entry is committed.
+	expectedPCR []byte
+	// eventData is the AAEL plaintext of the pending entry.
+	eventData string
+	// eventOffset is the offset of the entry in the event-log file.
+	eventOffset uint64
+}
+
+// EventLog maintains the AAEL and extends entries into a measurement register.
+type EventLog struct {
+	writer   writer
+	extender attester.Attester
+	alg      string
+	pcr      uint64
+}
+
+// New opens (creating if necessary) the AA event log and returns an EventLog
+// that extends into pcr, recovering from any WAL left by a previous crash.
+func New(extender attester.Attester, pcr uint64) (*EventLog, error) {
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create eventlog parent dir: %w", err)
+	}
+	file, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("open AAEL file: %w", err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, fmt.Errorf("stat AAEL file: %w", err)
+	}
+	w := &fileWriter{file: file, pos: uint64(info.Size())}
+
+	alg := string(extender.CcelHashAlgorithm())
+	digestLen, err := hashalg.Len(alg)
+	if err != nil {
+		file.Close()
+		return nil, err
+	}
+
+	el := &EventLog{writer: w, extender: extender, alg: alg, pcr: pcr}
+
+	wal, err := readWalCache(digestLen)
+	if err != nil {
+		file.Close()
+		return nil, fmt.Errorf("failed to read wal cache. This is a significant error caused by a previous crash. Please try delete %q and restart the attestation agent: %w", walCachePath, err)
+	}
+	if wal == nil {
+		return el, nil
+	}
+
+	if err := el.recover(wal); err != nil {
+		file.Close()
+		return nil, err
+	}
+	return el, nil
+}
+
+// recover replays a pending WAL record after a crash: it re-extends the
+// register if that step did not complete, then re-appends the log entry.
+func (el *EventLog) recover(wal *walCache) error {
+	currentPCR, err := el.extender.GetRuntimeMeasurement(el.pcr)
+	if err != nil {
+		return fmt.Errorf("get runtime measurement: %w", err)
+	}
+
+	event, err := parseEvent(wal.eventData)
+	if err != nil {
+		return err
+	}
+	entry, eventDigest, err := newTcg2Entry(event).digest(el.alg)
+	if err != nil {
+		return err
+	}
+	entryBytes := entry.bytes()
+
+	// If the register has not been extended yet, extend it now.
+	if !bytes.Equal(currentPCR, wal.expectedPCR) {
+		status := append(append([]byte{}, currentPCR...), eventDigest...)
+		updated, err := hashalg.Digest(el.alg, status)
+		if err != nil {
+			return err
+		}
+		if !bytes.Equal(updated, wal.expectedPCR) {
+			return fmt.Errorf("fatal error when recovering. The eventlog file %s is probably corrupted, or other process has extended the target PCR %d", logPath, el.pcr)
+		}
+		if err := el.extender.ExtendRuntimeMeasurement(eventDigest, el.pcr); err != nil {
+			return err
+		}
+	}
+
+	if err := el.writer.seek(wal.eventOffset); err != nil {
+		return err
+	}
+	if err := el.writer.write(entryBytes); err != nil {
+		return err
+	}
+	return cleanWalCache()
+}
+
+// ExtendEntry atomically extends the register with event and appends it to the
+// AAEL. The ordering (WAL write, extend register, append log, clean WAL) makes
+// the pair recoverable after a crash at any point.
+func (el *EventLog) ExtendEntry(event Event, pcr uint64) error {
+	aaelEventData := event.String()
+	rtmr := el.extender.PcrToCcmr(el.pcr)
+	entry, eventDigest, err := newTcg2Entry(event).
+		withTargetMeasurementRegister(uint32(rtmr)).
+		digest(el.alg)
+	if err != nil {
+		return err
+	}
+	entryBytes := entry.bytes()
+
+	currentPCR, err := el.extender.GetRuntimeMeasurement(pcr)
+	if err != nil {
+		return err
+	}
+	status := append(append([]byte{}, currentPCR...), eventDigest...)
+	expectedPCR, err := hashalg.Digest(el.alg, status)
+	if err != nil {
+		return err
+	}
+
+	if err := writeWalCache(walCache{
+		expectedPCR: expectedPCR,
+		eventData:   aaelEventData,
+		eventOffset: el.writer.currentPos(),
+	}); err != nil {
+		return fmt.Errorf("write wal cache file failed: %w", err)
+	}
+
+	if err := el.extender.ExtendRuntimeMeasurement(eventDigest, pcr); err != nil {
+		return err
+	}
+	if err := el.writer.write(entryBytes); err != nil {
+		return fmt.Errorf("write log entry: %w", err)
+	}
+	if err := cleanWalCache(); err != nil {
+		return fmt.Errorf("remove wal cache file failed: %w", err)
+	}
+	return nil
+}
+
+// writeWalCache persists a pending record before the register is extended.
+//
+// The record layout is event_offset(u64) || expected_pcr || event_data. We use
+// little-endian for the offset consistently on both the write and read paths
+// (the upstream Rust writes big-endian but reads little-endian; the WAL file is
+// process-local and never shared across implementations, so a self-consistent
+// little-endian encoding is correct here).
+func writeWalCache(w walCache) error {
+	file, err := os.Create(walCachePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	var offset [8]byte
+	binary.LittleEndian.PutUint64(offset[:], w.eventOffset)
+	if _, err := file.Write(offset[:]); err != nil {
+		return err
+	}
+	if _, err := file.Write(w.expectedPCR); err != nil {
+		return err
+	}
+	if _, err := file.Write([]byte(w.eventData)); err != nil {
+		return err
+	}
+	return file.Sync()
+}
+
+// cleanWalCache removes the WAL cache file.
+func cleanWalCache() error {
+	return os.Remove(walCachePath)
+}
+
+// readWalCache reads the WAL cache file, or returns (nil, nil) if none exists.
+func readWalCache(digestLen int) (*walCache, error) {
+	data, err := os.ReadFile(walCachePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(data) < 8+digestLen {
+		return nil, fmt.Errorf("wal cache too short: %d bytes", len(data))
+	}
+	offset := binary.LittleEndian.Uint64(data[:8])
+	expectedPCR := append([]byte{}, data[8:8+digestLen]...)
+	eventData := string(data[8+digestLen:])
+	return &walCache{
+		expectedPCR: expectedPCR,
+		eventData:   eventData,
+		eventOffset: offset,
+	}, nil
+}

--- a/attestation-agent/agent-go/eventlog/eventlog_test.go
+++ b/attestation-agent/agent-go/eventlog/eventlog_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package eventlog
+
+import (
+	"bytes"
+	"crypto/sha512"
+	"os"
+	"path/filepath"
+	"testing"
+
+	attester "github.com/confidential-containers/guest-components/attestation-agent/attester-go"
+)
+
+// fakeExtender is an in-memory attester used to exercise the event log without
+// touching real hardware or the platform's fixed register/log paths. It
+// measures with SHA-384 (48-byte register).
+type fakeExtender struct {
+	reg []byte
+}
+
+func newFakeExtender() *fakeExtender { return &fakeExtender{reg: make([]byte, 48)} }
+
+func (f *fakeExtender) GetEvidence(_ []byte) (attester.TeeEvidence, error) { return nil, nil }
+
+func (f *fakeExtender) ExtendRuntimeMeasurement(digest []byte, _ uint64) error {
+	d := sha512.Sum384(append(append([]byte{}, f.reg...), digest...))
+	f.reg = d[:]
+	return nil
+}
+
+func (f *fakeExtender) BindInitData(_ []byte) (attester.InitDataResult, error) {
+	return attester.InitDataUnsupported, nil
+}
+
+func (f *fakeExtender) GetRuntimeMeasurement(_ uint64) ([]byte, error) {
+	return append([]byte{}, f.reg...), nil
+}
+
+func (f *fakeExtender) PcrToCcmr(_ uint64) uint64                 { return 1 }
+func (f *fakeExtender) CcelHashAlgorithm() attester.HashAlgorithm { return attester.HashSha384 }
+
+// captureWriter is an in-memory writer implementing the unexported writer
+// interface.
+type captureWriter struct {
+	buf []byte
+	pos uint64
+}
+
+func (w *captureWriter) write(data []byte) error {
+	w.buf = append(w.buf, data...)
+	w.pos += uint64(len(data))
+	return nil
+}
+func (w *captureWriter) seek(pos uint64) error { w.pos = pos; return nil }
+func (w *captureWriter) currentPos() uint64    { return w.pos }
+
+// redirectPaths points the event log at a temporary directory for the duration
+// of a test.
+func redirectPaths(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	oldParent, oldLog, oldWal := parentDir, logPath, walCachePath
+	parentDir = dir
+	logPath = filepath.Join(dir, "eventlog")
+	walCachePath = filepath.Join(dir, ".wal_event_entry")
+	t.Cleanup(func() {
+		parentDir, logPath, walCachePath = oldParent, oldLog, oldWal
+	})
+}
+
+func TestExtendEntry(t *testing.T) {
+	redirectPaths(t)
+	fe := newFakeExtender()
+	cw := &captureWriter{}
+	el := &EventLog{writer: cw, extender: fe, alg: "sha384", pcr: 17}
+
+	prevReg := append([]byte{}, fe.reg...)
+	for _, content := range []string{"content1", "content2"} {
+		event, err := NewEvent("domain", "operation", content)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Independently derive the expected entry bytes and register value.
+		entry, digest, err := newTcg2Entry(event).withTargetMeasurementRegister(1).digest("sha384")
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantReg := sha512.Sum384(append(append([]byte{}, prevReg...), digest...))
+		wantBuf := entry.bytes()
+
+		if err := el.ExtendEntry(event, 17); err != nil {
+			t.Fatalf("ExtendEntry(%s): %v", content, err)
+		}
+
+		if !bytes.Equal(fe.reg, wantReg[:]) {
+			t.Errorf("register mismatch after %s", content)
+		}
+		if !bytes.HasSuffix(cw.buf, wantBuf) {
+			t.Errorf("writer did not receive expected entry bytes for %s", content)
+		}
+		if _, err := os.Stat(walCachePath); !os.IsNotExist(err) {
+			t.Errorf("WAL cache not cleaned after %s (err=%v)", content, err)
+		}
+		prevReg = wantReg[:]
+	}
+}
+
+// TestRecoverExtendsAndAppends simulates a crash after the WAL was written but
+// before the register was extended and the entry appended: New must replay it.
+func TestRecoverExtendsAndAppends(t *testing.T) {
+	redirectPaths(t)
+	fe := newFakeExtender()
+
+	event, err := NewEvent("domain", "operation", "content")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Recovery re-derives the entry with the default target measurement register.
+	entry, digest, err := newTcg2Entry(event).digest("sha384")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := sha512.Sum384(append(append([]byte{}, fe.reg...), digest...))
+
+	if err := writeWalCache(walCache{
+		expectedPCR: expected[:],
+		eventData:   event.String(),
+		eventOffset: 0,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	el, err := New(fe, 17)
+	if err != nil {
+		t.Fatalf("New (recovery): %v", err)
+	}
+	_ = el
+
+	if !bytes.Equal(fe.reg, expected[:]) {
+		t.Error("register was not extended during recovery")
+	}
+	if _, err := os.Stat(walCachePath); !os.IsNotExist(err) {
+		t.Error("WAL cache not cleaned after recovery")
+	}
+	logged, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(logged, entry.bytes()) {
+		t.Error("recovered entry not appended to the log file")
+	}
+}

--- a/attestation-agent/agent-go/eventlog/tcg2.go
+++ b/attestation-agent/agent-go/eventlog/tcg2.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2025 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package eventlog
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	"github.com/confidential-containers/guest-components/attestation-agent/agent-go/internal/hashalg"
+)
+
+// TCG algorithm identifiers (TCG Algorithm Registry), used in the digest list
+// of a TCG2 event entry.
+const (
+	tcgAlgSha256 uint16 = 0xB
+	tcgAlgSha384 uint16 = 0xC
+	tcgAlgSha512 uint16 = 0xD
+	tcgAlgSm3    uint16 = 0x12
+)
+
+// tcgAlgorithm maps a hash-algorithm identifier to its TCG registry code.
+func tcgAlgorithm(alg string) (uint16, error) {
+	switch alg {
+	case hashalg.SHA256:
+		return tcgAlgSha256, nil
+	case hashalg.SHA384:
+		return tcgAlgSha384, nil
+	case hashalg.SHA512:
+		return tcgAlgSha512, nil
+	case hashalg.SM3:
+		return tcgAlgSm3, nil
+	default:
+		return 0, fmt.Errorf("eventlog: unsupported hash algorithm %q", alg)
+	}
+}
+
+// Tagged event type ID (EV_EVENT_TAG).
+const evEventTagType uint32 = 0x6
+
+// AAEL tagged event ID, ASCII of "AAEL".
+const aaelTaggedEventID uint32 = 0x4141454c
+
+// Event is a single AAEL log entry: a `domain operation content` triple. The
+// content must not contain a newline.
+type Event struct {
+	domain    string
+	operation string
+	content   string
+}
+
+// NewEvent validates and builds an Event, mirroring Rust Event::new.
+func NewEvent(domain, operation, content string) (Event, error) {
+	if strings.ContainsRune(content, '\n') {
+		return Event{}, fmt.Errorf("eventlog: content contains newline")
+	}
+	return Event{domain: domain, operation: operation, content: content}, nil
+}
+
+// parseEvent parses an Event from its `domain operation content` string form,
+// mirroring the Rust TryFrom<&str> for Event.
+func parseEvent(s string) (Event, error) {
+	first := strings.IndexByte(s, ' ')
+	if first < 0 {
+		return Event{}, fmt.Errorf("eventlog: no space found in event string")
+	}
+	rel := strings.IndexByte(s[first+1:], ' ')
+	if rel < 0 {
+		return Event{}, fmt.Errorf("eventlog: no second space found in event string")
+	}
+	second := first + 1 + rel
+	return NewEvent(s[:first], s[first+1:second], s[second+1:])
+}
+
+// String renders the AAEL plaintext form `domain operation content`.
+func (e Event) String() string {
+	return e.domain + " " + e.operation + " " + e.content
+}
+
+// taggedEventBytes serializes the AAEL tagged event: tagged_id(LE u32) ||
+// size(LE u32) || plaintext.
+func (e Event) taggedEventBytes() []byte {
+	plaintext := []byte(e.String())
+	buf := make([]byte, 0, 8+len(plaintext))
+	buf = binary.LittleEndian.AppendUint32(buf, aaelTaggedEventID)
+	buf = binary.LittleEndian.AppendUint32(buf, uint32(len(plaintext)))
+	buf = append(buf, plaintext...)
+	return buf
+}
+
+// tcg2Entry is a TCG2 event entry (event type EV_EVENT_TAG) wrapping an AAEL
+// tagged event as its event-data section.
+type tcg2Entry struct {
+	targetMeasurementRegister uint32
+	eventTypeNum              uint32
+	digestCount               uint32
+	digestAlg                 uint16
+	digestValue               []byte
+	eventData                 []byte
+}
+
+// newTcg2Entry builds a TCG2 entry from an Event, mirroring the Rust
+// From<Event> for Tcg2EventEntry (default target measurement register 1, empty
+// digest list).
+func newTcg2Entry(e Event) tcg2Entry {
+	return tcg2Entry{
+		targetMeasurementRegister: 1,
+		eventTypeNum:              evEventTagType,
+		digestCount:               0,
+		eventData:                 e.taggedEventBytes(),
+	}
+}
+
+// withTargetMeasurementRegister sets the target measurement register.
+func (t tcg2Entry) withTargetMeasurementRegister(reg uint32) tcg2Entry {
+	t.targetMeasurementRegister = reg
+	return t
+}
+
+// digest computes the digest of the event-data section under alg, populating
+// the single-entry digest list, and returns the updated entry together with the
+// raw digest (used to extend the measurement register).
+func (t tcg2Entry) digest(alg string) (tcg2Entry, []byte, error) {
+	code, err := tcgAlgorithm(alg)
+	if err != nil {
+		return tcg2Entry{}, nil, err
+	}
+	d, err := hashalg.Digest(alg, t.eventData)
+	if err != nil {
+		return tcg2Entry{}, nil, err
+	}
+	t.digestCount = 1
+	t.digestAlg = code
+	t.digestValue = d
+	return t, d, nil
+}
+
+// bytes serializes the TCG2 event entry in little-endian wire form.
+func (t tcg2Entry) bytes() []byte {
+	buf := make([]byte, 0, 16+len(t.digestValue)+len(t.eventData))
+	buf = binary.LittleEndian.AppendUint32(buf, t.targetMeasurementRegister)
+	buf = binary.LittleEndian.AppendUint32(buf, t.eventTypeNum)
+	buf = binary.LittleEndian.AppendUint32(buf, t.digestCount)
+	if t.digestCount > 0 {
+		buf = binary.LittleEndian.AppendUint16(buf, t.digestAlg)
+		buf = append(buf, t.digestValue...)
+	}
+	buf = binary.LittleEndian.AppendUint32(buf, uint32(len(t.eventData)))
+	buf = append(buf, t.eventData...)
+	return buf
+}

--- a/attestation-agent/agent-go/eventlog/tcg2_test.go
+++ b/attestation-agent/agent-go/eventlog/tcg2_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2025 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package eventlog
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+// TestEventDigest reproduces the Rust attestation-agent tcg2 digest vectors,
+// confirming the TCG2 event-data byte layout is compatible.
+func TestEventDigest(t *testing.T) {
+	cases := []struct {
+		alg  string
+		want string
+	}{
+		{"sha256", "46df8dacf00a07d34a83cdf56d7978697790787cf2ba1432ef7c38f22cd96351"},
+		{"sha384", "dad5f0e226318ffa9839b75a472c6aa7fdb5834949d0a0a22990cf04d5692440fb00f3aa0609db7e49cd8d793f670d02"},
+		{"sha512", "b708d222ca8bd44dfe6ba0c4ca2cbb72379276fba8091025217064be45a813e5d6124ccf073219edb617d1faf007d55061465bdf34b7437dbdc9a7405bd4e9c0"},
+	}
+	for _, c := range cases {
+		event, err := NewEvent("domain", "operation", "content")
+		if err != nil {
+			t.Fatalf("NewEvent: %v", err)
+		}
+		_, digest, err := newTcg2Entry(event).digest(c.alg)
+		if err != nil {
+			t.Fatalf("digest(%s): %v", c.alg, err)
+		}
+		got := hex.EncodeToString(digest)
+		if got != c.want {
+			t.Errorf("digest(%s) = %s, want %s", c.alg, got, c.want)
+		}
+	}
+}
+
+func TestNewEventRejectsNewline(t *testing.T) {
+	if _, err := NewEvent("d", "o", "has\nnewline"); err == nil {
+		t.Fatal("expected error for content containing newline")
+	}
+	if _, err := NewEvent("d", "o", "ok"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseEventRoundTrip(t *testing.T) {
+	e, err := NewEvent("domain", "operation", "some content with spaces")
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := parseEvent(e.String())
+	if err != nil {
+		t.Fatalf("parseEvent: %v", err)
+	}
+	if parsed.String() != e.String() {
+		t.Errorf("round trip mismatch: %q != %q", parsed.String(), e.String())
+	}
+	if parsed.domain != "domain" || parsed.operation != "operation" || parsed.content != "some content with spaces" {
+		t.Errorf("parsed fields wrong: %+v", parsed)
+	}
+}
+
+func TestParseEventErrors(t *testing.T) {
+	if _, err := parseEvent("nospace"); err == nil {
+		t.Error("expected error for string without spaces")
+	}
+	if _, err := parseEvent("onlyone space"); err == nil {
+		t.Error("expected error for string with a single space")
+	}
+}

--- a/attestation-agent/agent-go/go.mod
+++ b/attestation-agent/agent-go/go.mod
@@ -1,0 +1,15 @@
+module github.com/confidential-containers/guest-components/attestation-agent/agent-go
+
+go 1.21
+
+require (
+	github.com/BurntSushi/toml v1.4.0
+	github.com/confidential-containers/guest-components/attestation-agent/attester-go v0.0.0
+)
+
+require (
+	github.com/NVIDIA/go-nvml v0.13.0-1 // indirect
+	golang.org/x/sys v0.20.0 // indirect
+)
+
+replace github.com/confidential-containers/guest-components/attestation-agent/attester-go => ../attester-go

--- a/attestation-agent/agent-go/go.sum
+++ b/attestation-agent/agent-go/go.sum
@@ -1,0 +1,14 @@
+github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
+github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/NVIDIA/go-nvml v0.13.0-1 h1:OLX8Jq3dONuPOQPC7rndB6+iDmDakw0XTYgzMxObkEw=
+github.com/NVIDIA/go-nvml v0.13.0-1/go.mod h1:+KNA7c7gIBH7SKSJ1ntlwkfN80zdx8ovl4hrK3LmPt4=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
+golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/attestation-agent/agent-go/initdata/initdata.go
+++ b/attestation-agent/agent-go/initdata/initdata.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2025 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package initdata is a pure-Go re-implementation of the attestation-agent
+// crate `initdata` module. It parses the Initdata TOML document and computes
+// its digest under the declared algorithm.
+package initdata
+
+import (
+	"fmt"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/confidential-containers/guest-components/attestation-agent/agent-go/internal/hashalg"
+)
+
+// Initdata is the parsed Initdata document. See
+// https://github.com/confidential-containers/trustee/blob/main/kbs/docs/initdata.md
+type Initdata struct {
+	// Version is the Initdata format version.
+	Version string `toml:"version"`
+
+	// Algorithm is the hash algorithm used to digest the raw TOML.
+	Algorithm string `toml:"algorithm"`
+
+	// Data is the arbitrary key/value payload.
+	Data map[string]string `toml:"data"`
+}
+
+// ParseAndGetDigest parses the Initdata TOML and returns it together with the
+// digest of the raw TOML bytes under the declared algorithm, mirroring the Rust
+// Initdata::parse_and_get_digest.
+func ParseAndGetDigest(tomlStr string) (*Initdata, []byte, error) {
+	var initdata Initdata
+	if _, err := toml.Decode(tomlStr, &initdata); err != nil {
+		return nil, nil, fmt.Errorf("initdata: parse toml: %w", err)
+	}
+	digest, err := hashalg.Digest(initdata.Algorithm, []byte(tomlStr))
+	if err != nil {
+		return nil, nil, err
+	}
+	return &initdata, digest, nil
+}

--- a/attestation-agent/agent-go/initdata/initdata_test.go
+++ b/attestation-agent/agent-go/initdata/initdata_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2025 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package initdata
+
+import (
+	"bytes"
+	"crypto/sha512"
+	"testing"
+)
+
+func TestParseAndGetDigest(t *testing.T) {
+	const doc = `version = "0.1.0"
+algorithm = "sha384"
+
+[data]
+"key1" = "value1"
+"key2" = "value2"
+`
+	initdata, digest, err := ParseAndGetDigest(doc)
+	if err != nil {
+		t.Fatalf("ParseAndGetDigest: %v", err)
+	}
+	if initdata.Version != "0.1.0" {
+		t.Errorf("version = %q", initdata.Version)
+	}
+	if initdata.Algorithm != "sha384" {
+		t.Errorf("algorithm = %q", initdata.Algorithm)
+	}
+	if initdata.Data["key1"] != "value1" || initdata.Data["key2"] != "value2" {
+		t.Errorf("data = %+v", initdata.Data)
+	}
+
+	want := sha512.Sum384([]byte(doc))
+	if !bytes.Equal(digest, want[:]) {
+		t.Errorf("digest mismatch: got %x want %x", digest, want[:])
+	}
+}
+
+func TestParseAndGetDigestUnsupportedAlg(t *testing.T) {
+	const doc = `version = "0.1.0"
+algorithm = "md5"
+
+[data]
+`
+	if _, _, err := ParseAndGetDigest(doc); err == nil {
+		t.Error("expected error for unsupported algorithm")
+	}
+}

--- a/attestation-agent/agent-go/internal/hashalg/hashalg.go
+++ b/attestation-agent/agent-go/internal/hashalg/hashalg.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package hashalg resolves the platform hash algorithm (as reported by an
+// attester's CcelHashAlgorithm) to a concrete digest, mirroring the Rust
+// kbs_types::HashAlgorithm::digest / digest_len helpers used by the event log.
+package hashalg
+
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+	"fmt"
+
+	"github.com/confidential-containers/guest-components/attestation-agent/agent-go/internal/sm3"
+)
+
+// Algorithm identifiers, matching the lowercase kbs_types::HashAlgorithm
+// serialization surfaced through attester-go's api.HashAlgorithm.
+const (
+	SHA256 = "sha256"
+	SHA384 = "sha384"
+	SHA512 = "sha512"
+	SM3    = "sm3"
+)
+
+// Len returns the digest length in bytes for alg.
+func Len(alg string) (int, error) {
+	switch alg {
+	case SHA256, SM3:
+		return 32, nil
+	case SHA384:
+		return 48, nil
+	case SHA512:
+		return 64, nil
+	default:
+		return 0, fmt.Errorf("hashalg: unsupported algorithm %q", alg)
+	}
+}
+
+// Digest computes the digest of data under alg.
+func Digest(alg string, data []byte) ([]byte, error) {
+	switch alg {
+	case SHA256:
+		d := sha256.Sum256(data)
+		return d[:], nil
+	case SHA384:
+		d := sha512.Sum384(data)
+		return d[:], nil
+	case SHA512:
+		d := sha512.Sum512(data)
+		return d[:], nil
+	case SM3:
+		d := sm3.Sum(data)
+		return d[:], nil
+	default:
+		return nil, fmt.Errorf("hashalg: unsupported algorithm %q", alg)
+	}
+}

--- a/attestation-agent/agent-go/internal/sm3/sm3.go
+++ b/attestation-agent/agent-go/internal/sm3/sm3.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package sm3 implements the SM3 (GB/T 32905-2016) hash, so the event log has
+// no external crypto dependency when a platform (e.g. Hygon CSV) measures with
+// SM3. It is a verbatim copy of the attester-go internal/sm3 implementation;
+// Go's internal/ visibility rule prevents importing it across modules.
+package sm3
+
+import "encoding/binary"
+
+// Sum computes the SM3 256-bit digest of data.
+func Sum(data []byte) [32]byte {
+	iv := [8]uint32{
+		0x7380166f, 0x4914b2b9, 0x172442d7, 0xda8a0600,
+		0xa96f30bc, 0x163138aa, 0xe38dee4d, 0xb0fb0e4e,
+	}
+
+	// padding
+	msgLen := uint64(len(data)) * 8
+	msg := make([]byte, len(data))
+	copy(msg, data)
+	msg = append(msg, 0x80)
+	for len(msg)%64 != 56 {
+		msg = append(msg, 0x00)
+	}
+	var lenBuf [8]byte
+	binary.BigEndian.PutUint64(lenBuf[:], msgLen)
+	msg = append(msg, lenBuf[:]...)
+
+	ff0 := func(x, y, z uint32) uint32 { return x ^ y ^ z }
+	ff1 := func(x, y, z uint32) uint32 { return (x & y) | (x & z) | (y & z) }
+	gg0 := func(x, y, z uint32) uint32 { return x ^ y ^ z }
+	gg1 := func(x, y, z uint32) uint32 { return (x & y) | (^x & z) }
+	rotl := func(x uint32, n uint) uint32 { return (x << n) | (x >> (32 - n)) }
+	p0 := func(x uint32) uint32 { return x ^ rotl(x, 9) ^ rotl(x, 17) }
+	p1 := func(x uint32) uint32 { return x ^ rotl(x, 15) ^ rotl(x, 23) }
+
+	v := iv
+	for b := 0; b < len(msg); b += 64 {
+		block := msg[b : b+64]
+		var w [68]uint32
+		for i := 0; i < 16; i++ {
+			w[i] = binary.BigEndian.Uint32(block[i*4:])
+		}
+		for i := 16; i < 68; i++ {
+			w[i] = p1(w[i-16]^w[i-9]^rotl(w[i-3], 15)) ^ rotl(w[i-13], 7) ^ w[i-6]
+		}
+		var w1 [64]uint32
+		for i := 0; i < 64; i++ {
+			w1[i] = w[i] ^ w[i+4]
+		}
+
+		a, bb, c, d := v[0], v[1], v[2], v[3]
+		e, f, g, h := v[4], v[5], v[6], v[7]
+		for j := 0; j < 64; j++ {
+			var tj uint32
+			if j < 16 {
+				tj = 0x79cc4519
+			} else {
+				tj = 0x7a879d8a
+			}
+			ss1 := rotl(rotl(a, 12)+e+rotl(tj, uint(j)%32), 7)
+			ss2 := ss1 ^ rotl(a, 12)
+			var tt1, tt2 uint32
+			if j < 16 {
+				tt1 = ff0(a, bb, c) + d + ss2 + w1[j]
+				tt2 = gg0(e, f, g) + h + ss1 + w[j]
+			} else {
+				tt1 = ff1(a, bb, c) + d + ss2 + w1[j]
+				tt2 = gg1(e, f, g) + h + ss1 + w[j]
+			}
+			d = c
+			c = rotl(bb, 9)
+			bb = a
+			a = tt1
+			h = g
+			g = rotl(f, 19)
+			f = e
+			e = p0(tt2)
+		}
+		v[0] ^= a
+		v[1] ^= bb
+		v[2] ^= c
+		v[3] ^= d
+		v[4] ^= e
+		v[5] ^= f
+		v[6] ^= g
+		v[7] ^= h
+	}
+
+	var out [32]byte
+	for i := 0; i < 8; i++ {
+		binary.BigEndian.PutUint32(out[i*4:], v[i])
+	}
+	return out
+}

--- a/attestation-agent/agent-go/token/cocoas.go
+++ b/attestation-agent/agent-go/token/cocoas.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package token
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	attester "github.com/confidential-containers/guest-components/attestation-agent/attester-go"
+
+	"github.com/confidential-containers/guest-components/attestation-agent/agent-go/config"
+)
+
+// CoCoASTokenGetter obtains an attestation token from a CoCo Attestation
+// Service.
+type CoCoASTokenGetter struct {
+	asURI  string
+	client *http.Client
+}
+
+// NewCoCoAS builds a CoCoASTokenGetter from config, mirroring the Rust
+// CoCoASTokenGetter::new: the TRUSTEE_URL environment variable takes precedence
+// over the config URL and, when set, points at the trustee gateway (the
+// `/attestation-service` path is appended).
+func NewCoCoAS(cfg *config.CoCoASConfig) *CoCoASTokenGetter {
+	asURI := cfg.URL
+	if envURL, ok := os.LookupEnv("TRUSTEE_URL"); ok {
+		asURI = envURL + "/attestation-service"
+	}
+	return &CoCoASTokenGetter{asURI: asURI, client: http.DefaultClient}
+}
+
+type verificationRequest struct {
+	Tee            string  `json:"tee"`
+	Evidence       string  `json:"evidence"`
+	AdditionalData *string `json:"additional_data"`
+}
+
+type attestationRequest struct {
+	VerificationRequests []verificationRequest `json:"verification_requests"`
+	PolicyIDs            []string              `json:"policy_ids"`
+}
+
+// GetToken collects evidence from the detected TEE and posts it to the
+// Attestation Service, returning the token bytes on success. additionalData is
+// optional (pass nil for none).
+func (g *CoCoASTokenGetter) GetToken(additionalData *string) ([]byte, error) {
+	primaryTee := attester.DetectTeeType()
+	att, err := attester.New(primaryTee)
+	if err != nil {
+		return nil, err
+	}
+	evidence, err := att.GetEvidence(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	request := attestationRequest{
+		VerificationRequests: []verificationRequest{{
+			Tee:            string(primaryTee),
+			Evidence:       base64.RawURLEncoding.EncodeToString(evidence),
+			AdditionalData: additionalData,
+		}},
+		PolicyIDs: policyIDs(),
+	}
+	body, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, g.asURI+"/attestation", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if apiKey, ok := os.LookupEnv("TRUSTEE_API_KEY"); ok {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Remote Attestation Failed, AS Response: %q", string(respBody))
+	}
+	return respBody, nil
+}
+
+// policyIDs parses COCO_AS_POLICY_ID (comma-separated) into a trimmed,
+// non-empty list, matching the Rust behaviour.
+func policyIDs() []string {
+	raw := os.Getenv("COCO_AS_POLICY_ID")
+	ids := []string{}
+	for _, s := range strings.Split(raw, ",") {
+		if s == "" {
+			continue
+		}
+		ids = append(ids, strings.TrimSpace(s))
+	}
+	return ids
+}

--- a/attestation-agent/agent-go/token/kbs.go
+++ b/attestation-agent/agent-go/token/kbs.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package token
+
+import (
+	"errors"
+	"os"
+
+	"github.com/confidential-containers/guest-components/attestation-agent/agent-go/config"
+)
+
+// ErrKbsNotImplemented is returned by KbsTokenGetter.GetToken. Obtaining a KBS
+// token requires the KBS background-check protocol (RCAR handshake + TEE key
+// pair), implemented by the Rust `kbs_protocol` crate, which has not yet been
+// ported to Go.
+var ErrKbsNotImplemented = errors.New("token: KBS token is not implemented in the Go port (requires a Go port of kbs_protocol)")
+
+// KbsTokenGetter obtains an attestation token from a Key Broker Service.
+//
+// The configuration surface (host URL resolution, optional cert) mirrors the
+// Rust KbsTokenGetter, but GetToken is not yet functional; see
+// ErrKbsNotImplemented.
+type KbsTokenGetter struct {
+	kbsHostURL string
+	cert       *string
+}
+
+// NewKbs builds a KbsTokenGetter from config, mirroring the Rust
+// KbsTokenGetter::new: TRUSTEE_URL takes precedence over the config URL.
+func NewKbs(cfg *config.KbsConfig) *KbsTokenGetter {
+	hostURL := cfg.URL
+	if envURL, ok := os.LookupEnv("TRUSTEE_URL"); ok {
+		hostURL = envURL
+	}
+	return &KbsTokenGetter{kbsHostURL: hostURL, cert: cfg.Cert}
+}
+
+// GetToken is not implemented; see ErrKbsNotImplemented.
+func (g *KbsTokenGetter) GetToken(initdata *string) ([]byte, error) {
+	return nil, ErrKbsNotImplemented
+}

--- a/attestation-agent/agent-go/token/token.go
+++ b/attestation-agent/agent-go/token/token.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package token is a pure-Go re-implementation of the attestation-agent crate
+// `token` module. It obtains an attestation token from a remote service.
+//
+// The CoCoAS token getter is fully implemented. The KBS token getter requires
+// the KBS background-check protocol (the Rust `kbs_protocol` crate, including
+// the RCAR handshake and TEE key pair), which is not yet ported to Go; its
+// GetToken therefore returns ErrKbsNotImplemented.
+package token
+
+import "fmt"
+
+// TokenType identifies the remote attestation-token source.
+type TokenType string
+
+const (
+	// TokenTypeKbs obtains a token from a Key Broker Service.
+	TokenTypeKbs TokenType = "kbs"
+	// TokenTypeCoCoAS obtains a token from a CoCo Attestation Service.
+	TokenTypeCoCoAS TokenType = "coco_as"
+)
+
+// ParseTokenType parses a token type string, mirroring the Rust
+// TokenType::from_str.
+func ParseTokenType(s string) (TokenType, error) {
+	switch TokenType(s) {
+	case TokenTypeKbs:
+		return TokenTypeKbs, nil
+	case TokenTypeCoCoAS:
+		return TokenTypeCoCoAS, nil
+	default:
+		return "", fmt.Errorf("token: unsupported token type %q", s)
+	}
+}

--- a/attestation-agent/agent-go/token/token_test.go
+++ b/attestation-agent/agent-go/token/token_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2024 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package token
+
+import (
+	"os"
+	"testing"
+
+	"github.com/confidential-containers/guest-components/attestation-agent/agent-go/config"
+)
+
+func TestParseTokenType(t *testing.T) {
+	for _, s := range []string{"kbs", "coco_as"} {
+		if _, err := ParseTokenType(s); err != nil {
+			t.Errorf("ParseTokenType(%q): unexpected error %v", s, err)
+		}
+	}
+	if _, err := ParseTokenType("bogus"); err == nil {
+		t.Error("expected error for unknown token type")
+	}
+}
+
+func TestKbsNotImplemented(t *testing.T) {
+	g := NewKbs(&config.KbsConfig{URL: "https://127.0.0.1:8080"})
+	if _, err := g.GetToken(nil); err != ErrKbsNotImplemented {
+		t.Errorf("expected ErrKbsNotImplemented, got %v", err)
+	}
+}
+
+func TestCoCoASURLResolution(t *testing.T) {
+	orig, had := os.LookupEnv("TRUSTEE_URL")
+	os.Unsetenv("TRUSTEE_URL")
+	t.Cleanup(func() {
+		if had {
+			os.Setenv("TRUSTEE_URL", orig)
+		}
+	})
+
+	// Without TRUSTEE_URL, the config URL is used as-is.
+	g := NewCoCoAS(&config.CoCoASConfig{URL: "http://as.example.com"})
+	if g.asURI != "http://as.example.com" {
+		t.Errorf("asURI = %q, want config url", g.asURI)
+	}
+
+	// With TRUSTEE_URL, the gateway path is appended.
+	t.Setenv("TRUSTEE_URL", "http://trustee.example.com")
+	g = NewCoCoAS(&config.CoCoASConfig{URL: "http://as.example.com"})
+	if g.asURI != "http://trustee.example.com/attestation-service" {
+		t.Errorf("asURI = %q, want gateway path", g.asURI)
+	}
+}


### PR DESCRIPTION
## What

Adds `attestation-agent/agent-go`, a pure-Go re-implementation of the attestation-agent **library crate** (`attestation-agent/attestation-agent`), layered on top of [`attester-go`](https://github.com/inclavare-containers/guest-components/tree/main/attestation-agent/attester-go). It exposes the attestation-agent service API (`AttestationAPIs`) to Go programs with **no cgo and no external shared library**.

## Why

To let Go programs use the full attestation-agent flow — not just evidence collection (`attester-go`) but also token retrieval, init-data binding and, most importantly, **runtime measurement extension with AAEL recording** — in-process, as a pure-Go module. The default build is `CGO_ENABLED=0`.

## What it implements

- **`AttestationAgent` / `AttestationAPIs`** — `GetEvidence`, `GetAdditionalEvidence`, `GetToken`, `ExtendRuntimeMeasurement`, `BindInitData`, `GetTeeType`, `GetAdditionalTees`, plus `New` / `Init` / `SetInitdataToml`.
- **`config`** — AA config parsing (TOML or JSON) with the same defaults, and `aa_kbc_params` resolution from the environment / kernel command line.
- **`eventlog`** — the AA Event Log (AAEL): TCG2 event encoding, extend-into-register through the attester, and a write-ahead log (WAL) that makes the "extend register + append log" pair crash-recoverable. The TCG2 event-data digest is **byte-compatible with the Rust implementation** (locked by the same unit-test vectors).
- **`initdata`** — parse the Initdata TOML and compute its digest.
- **`token`** — CoCoAS token getter (fully implemented).

## Scope / differences from the Rust crate

All following the scope already established by `attester-go`:

- **No cgo / no shared library.** Every platform is reached through `attester-go`'s native kernel interfaces.
- **`instance_info` is not ported** (AA instance info / heartbeat). An `[aa_instance]` section in an existing config file is ignored.
- **KBS token is not ported.** It needs the KBS background-check protocol (the Rust `kbs_protocol` crate: RCAR handshake + TEE key pair), which has no Go port yet; `token.KbsTokenGetter.GetToken` returns `token.ErrKbsNotImplemented`. The **CoCoAS** token is fully implemented.
- **No additional (device) attesters.** `attester-go` exposes none, so `GetAdditionalEvidence` returns empty and `GetAdditionalTees` is empty.

## Testing

`go test ./...` passes (incl. `-race`). Coverage:

- TCG2 digest **byte-compatibility vectors** (identical to the Rust attestation-agent tests).
- Event-log extend + **WAL crash-recovery** paths, driven by an in-memory attester.
- Config TOML/JSON parsing and defaults, `aa_kbc_params`, Initdata digest, token dispatch and CoCoAS URL resolution.

## Notes

- New self-contained Go module under `attestation-agent/agent-go`; does not touch the existing Rust crates.
- Consumes `attester-go` via a relative module `replace`. The only new external dependency is a pure-Go TOML parser (`github.com/BurntSushi/toml`).
