### PR TITLE
feat(cdh): add aliyun KMS attestation client to fetch resources by remote attestation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,6 +1271,7 @@ dependencies = [
  "reqwest 0.12.9",
  "resource_uri",
  "ring",
+ "rsa",
  "rstest",
  "serde",
  "serde_json",

--- a/confidential-data-hub/docs/kms-providers/alibaba.md
+++ b/confidential-data-hub/docs/kms-providers/alibaba.md
@@ -53,6 +53,45 @@ Else if `client_type` is set to 'sts_token', provider_settings shall be as follo
 | `token_path`       | STS Token path inside the pod. The format of STS token is `AK:SK:STS`|
 | `region_id`        | KMS instance region ID                                               |
 
+Else if `client_type` is set to 'attestation', provider_settings shall be as following:
+
+| Name                | Required | Usage |
+| ------------------- | -------- | ----- |
+| `client_type`       | Yes      | Set to `attestation` |
+| `kms_instance_id`   | Yes      | The KMS instance ID to connect to |
+| `tee`               | No       | TEE type in the attestation document. Defaults to `tdx` |
+| `kms_ca_cert`       | No       | PEM-encoded KMS instance CA certificate. If omitted, CDH reads `PrivateKmsCA_<kms_instance_id>.pem` from the in-guest credential directory |
+| `ecs_ram_role_name` | Choice   | ECS RAM role whose temporary STS credential is fetched from IMDS |
+| `sts_token`         | Choice   | STS credential in `AK:SK:STS` format, used directly without accessing IMDS |
+
+Exactly one of `ecs_ram_role_name` and `sts_token` must be configured.
+
+For example, use an embedded CA certificate and an ECS RAM role:
+
+```json
+{
+    "client_type": "attestation",
+    "kms_instance_id": "kst-xxxxxx",
+    "ecs_ram_role_name": "kms-access-role",
+    "kms_ca_cert": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n"
+}
+```
+
+Or use an embedded CA certificate and a directly configured STS credential:
+
+```json
+{
+    "client_type": "attestation",
+    "kms_instance_id": "kst-xxxxxx",
+    "sts_token": "<AccessKeyId>:<AccessKeySecret>:<SecurityToken>",
+    "kms_ca_cert": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n"
+}
+```
+
+The direct STS credential is stored in the sealed secret's `provider_settings`.
+Use only short-lived STS credentials and protect the sealed secret from
+unauthorized access.
+
 ### Credential files
 
 To connect to a KMS instance with `client_type` set to 'client_key', a client key is needed. A client key is actually

--- a/confidential-data-hub/hub/Cargo.toml
+++ b/confidential-data-hub/hub/Cargo.toml
@@ -67,6 +67,7 @@ rand.workspace = true
 reqwest = { workspace = true, optional = true }
 resource_uri.path = "../../attestation-agent/deps/resource_uri"
 ring = "0.17"
+rsa = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_json.workspace = true
 sev = { path = "../../attestation-agent/deps/sev", optional = true }
@@ -110,16 +111,20 @@ default = ["aliyun", "kbs", "resource_injection", "bin", "ttrpc", "grpc", "cli"]
 # support aliyun stacks (KMS, ..)
 aliyun = [
     "chrono",
+    "dep:canon-json",
+    "dep:ttrpc",
     "hex",
     "p12",
     "prost",
     "reqwest/rustls-tls",
+    "dep:rsa",
     "sha2",
     "tempfile",
     "tonic",
     "url",
     "yasna",
     "protos/grpc",
+    "protos/ttrpc",
 ]
 
 # support coco-KBS to provide confidential resources

--- a/confidential-data-hub/hub/src/bin/secret_cli.rs
+++ b/confidential-data-hub/hub/src/bin/secret_cli.rs
@@ -174,10 +174,11 @@ async fn unseal_secret(unseal_args: &UnsealArgs) {
     };
 
     match secret_provider.as_str() {
-        "aliyun" => env::set_var(
-            "ALIYUN_IN_GUEST_KEY_PATH",
-            unseal_args.key_path.as_ref().expect("Key Path Required"),
-        ),
+        "aliyun" => {
+            if let Some(key_path) = unseal_args.key_path.as_ref() {
+                env::set_var("ALIYUN_IN_GUEST_KEY_PATH", key_path);
+            }
+        }
         "ehsm" => env::set_var(
             "EHSM_IN_GUEST_KEY_PATH",
             unseal_args.key_path.as_ref().expect("Key Path Required"),

--- a/confidential-data-hub/hub/src/kms/plugins/aliyun/client/attestation_client/mod.rs
+++ b/confidential-data-hub/hub/src/kms/plugins/aliyun/client/attestation_client/mod.rs
@@ -1,0 +1,497 @@
+// Copyright (c) 2026 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Aliyun KMS client that fetches confidential resources by remote attestation.
+//!
+//! Different from [`super::client_key_client::ClientKeyClient`] (which authenticates
+//! with a pre-provisioned client key), this client proves the running TEE to a KMS
+//! instance that has the Trustee Attestation Service integrated. The KMS encrypts the
+//! secret with an ephemeral public key that is bound into the TEE evidence, so the
+//! plaintext is only recoverable inside the attested TEE.
+//!
+//! Protocol (all requests are RPC-style `POST /` form bodies signed with the Aliyun
+//! POP HMAC-SHA1 scheme, sent to the dedicated instance endpoint over its private CA):
+//!
+//! 1. `GetChallenge` -> `{ Nonce, ChallengeToken }`
+//! 2. generate an ephemeral RSA-2048 key pair, build the `structured` runtime data
+//!    `{ challenge_token, nonce, tee-pubkey }`, hash it canonically with SHA-384 and
+//!    let the attestation-agent embed the hash into the TEE evidence report data
+//! 3. `GetSecretValue` with a `Recipient` carrying the evidence; the KMS verifies the
+//!    evidence and returns `CiphertextForRecipient` = RSA-OAEP(SHA-256)(secret)
+//! 4. decrypt `CiphertextForRecipient` with the ephemeral private key
+
+use std::{collections::BTreeMap, env, fmt::Write as _};
+
+use anyhow::{anyhow, bail, Context};
+use base64::{
+    engine::general_purpose::{STANDARD, URL_SAFE, URL_SAFE_NO_PAD},
+    Engine,
+};
+use canon_json::CanonicalFormatter;
+use chrono::Utc;
+use log::{debug, info};
+use protos::ttrpc::aa::{
+    attestation_agent::GetEvidenceRequest, attestation_agent_ttrpc::AttestationAgentServiceClient,
+};
+use rand::{distr::Alphanumeric, Rng};
+use reqwest::{Certificate, ClientBuilder};
+use rsa::{rand_core::OsRng, traits::PublicKeyParts, Oaep, RsaPrivateKey};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256, Sha384};
+use tokio::fs;
+use ttrpc::context;
+
+use super::super::annotations::AliSecretAnnotations;
+use super::sts_token_client::credential::{self, StsCredential};
+use super::ALIYUN_IN_GUEST_DEFAULT_KEY_PATH;
+use crate::kms::{Annotations, Error, ProviderSettings, Result};
+
+/// Default ttrpc socket the attestation-agent listens on inside a CoCo guest.
+const DEFAULT_AA_SOCKET: &str =
+    "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock";
+
+const AA_TTRPC_TIMEOUT_NANOS: i64 = 50 * 1000 * 1000 * 1000;
+
+/// `Recipient.KeyEncryptionAlgorithm` understood by the KMS Trustee integration.
+/// The secret is wrapped with RSAES-OAEP using SHA-256 for both the hash and MGF1.
+const KEY_ENCRYPTION_ALGORITHM: &str = "RSAES_OAEP_SHA_256";
+
+/// Bit length of the ephemeral RSA key pair bound into the evidence.
+const RSA_KEY_BITS: usize = 2048;
+
+/// Serialized [`crate::ProviderSettings`] for the attestation client.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AliAttestationProviderSettings {
+    /// KMS instance id, e.g. `kst-xxxxxx`.
+    pub kms_instance_id: String,
+
+    /// Region of the KMS instance, e.g. `cn-hangzhou`. Used to fetch the ECS RAM
+    /// role session credential from IMDS.
+    pub region_id: String,
+
+    /// ECS RAM role bound to the instance; its temporary STS credential (fetched
+    /// from IMDS) signs the KMS requests. This keeps no long-term secret in the TEE.
+    pub ecs_ram_role_name: String,
+
+    /// TEE type reported in the attestation document, e.g. `tdx`. Defaults to `tdx`.
+    #[serde(default = "default_tee")]
+    pub tee: String,
+}
+
+fn default_tee() -> String {
+    "tdx".to_string()
+}
+
+#[derive(Clone, Debug)]
+pub struct AttestationClient {
+    kms_instance_id: String,
+    endpoint: String,
+    region_id: String,
+    ecs_ram_role_name: String,
+    tee: String,
+    aa_socket: String,
+    http_client: reqwest::Client,
+}
+
+impl AttestationClient {
+    pub fn new(settings: AliAttestationProviderSettings, cert_pem: &str) -> Result<Self> {
+        let endpoint = format!(
+            "{}.cryptoservice.kms.aliyuncs.com",
+            settings.kms_instance_id
+        );
+        let cert = Certificate::from_pem(cert_pem.as_bytes()).map_err(|e| {
+            Error::AliyunKmsError(format!("read kms instance ca cert failed: {e:?}"))
+        })?;
+        let http_client = ClientBuilder::new()
+            .use_rustls_tls()
+            .add_root_certificate(cert)
+            .build()
+            .map_err(|e| Error::AliyunKmsError(format!("build http client failed: {e:?}")))?;
+
+        let aa_socket =
+            env::var("ATTESTATION_AGENT_SOCKET").unwrap_or_else(|_| DEFAULT_AA_SOCKET.to_string());
+
+        Ok(Self {
+            kms_instance_id: settings.kms_instance_id,
+            endpoint,
+            region_id: settings.region_id,
+            ecs_ram_role_name: settings.ecs_ram_role_name,
+            tee: settings.tee,
+            aa_socket,
+            http_client,
+        })
+    }
+
+    /// This new function is used by an in-pod client. It reads the KMS instance's
+    /// private CA certificate from the by-default in-guest key path, mirroring the
+    /// layout used by [`super::client_key_client::ClientKeyClient`].
+    pub async fn from_provider_settings(provider_settings: &ProviderSettings) -> Result<Self> {
+        let settings: AliAttestationProviderSettings =
+            serde_json::from_value(Value::Object(provider_settings.clone())).map_err(|e| {
+                Error::AliyunKmsError(format!("parse attestation provider setting failed: {e:?}"))
+            })?;
+
+        let key_path = env::var("ALIYUN_IN_GUEST_KEY_PATH")
+            .unwrap_or_else(|_| ALIYUN_IN_GUEST_DEFAULT_KEY_PATH.to_owned());
+        info!("ALIYUN_IN_GUEST_KEY_PATH = {}", key_path);
+
+        let cert_path = format!("{}/PrivateKmsCA_{}.pem", key_path, settings.kms_instance_id);
+        let cert_pem = fs::read_to_string(&cert_path).await.map_err(|e| {
+            Error::AliyunKmsError(format!(
+                "read kms instance pem cert from {cert_path} failed: {e:?}"
+            ))
+        })?;
+
+        Self::new(settings, &cert_pem)
+    }
+
+    /// Export the [`ProviderSettings`] of the current client.
+    pub fn export_provider_settings(&self) -> Result<ProviderSettings> {
+        let settings = AliAttestationProviderSettings {
+            kms_instance_id: self.kms_instance_id.clone(),
+            region_id: self.region_id.clone(),
+            ecs_ram_role_name: self.ecs_ram_role_name.clone(),
+            tee: self.tee.clone(),
+        };
+        let provider_settings = serde_json::to_value(settings)
+            .map_err(|e| {
+                Error::AliyunKmsError(format!("serialize ProviderSettings failed: {e:?}"))
+            })?
+            .as_object()
+            .expect("must be an object")
+            .to_owned();
+        Ok(provider_settings)
+    }
+
+    pub async fn get_secret(&self, name: &str, annotations: &Annotations) -> Result<Vec<u8>> {
+        let secret_settings: AliSecretAnnotations =
+            serde_json::from_value(Value::Object(annotations.clone())).map_err(|e| {
+                Error::AliyunKmsError(format!(
+                    "deserialize Secret annotations for get_secret failed: {e:?}"
+                ))
+            })?;
+
+        self.get_secret_inner(name, &secret_settings)
+            .await
+            .map_err(|e| Error::AliyunKmsError(format!("attestation get_secret failed: {e:#}")))
+    }
+
+    async fn get_secret_inner(
+        &self,
+        name: &str,
+        secret_settings: &AliSecretAnnotations,
+    ) -> anyhow::Result<Vec<u8>> {
+        let credential = self
+            .get_session_credential()
+            .await
+            .context("get STS session credential from IMDS")?;
+
+        let challenge = self
+            .get_challenge(&credential)
+            .await
+            .context("GetChallenge")?;
+
+        let keypair = RsaPrivateKey::new(&mut OsRng, RSA_KEY_BITS)
+            .context("generate ephemeral RSA key pair")?;
+        let recipient = self
+            .build_recipient(&challenge, &keypair)
+            .await
+            .context("build attestation Recipient")?;
+
+        let params = BTreeMap::from([
+            ("SecretName".to_string(), name.to_string()),
+            (
+                "VersionStage".to_string(),
+                secret_settings.version_stage.clone(),
+            ),
+            ("VersionId".to_string(), secret_settings.version_id.clone()),
+            ("FetchExtendedConfig".to_string(), "true".to_string()),
+            ("Recipient".to_string(), recipient),
+        ]);
+
+        let response = self
+            .call_api(&credential, "GetSecretValue", params)
+            .await
+            .context("GetSecretValue")?;
+
+        let ciphertext_for_recipient = response
+            .get("CiphertextForRecipient")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("response has no CiphertextForRecipient field"))?;
+
+        let ciphertext = STANDARD
+            .decode(ciphertext_for_recipient)
+            .context("base64-decode CiphertextForRecipient")?;
+
+        let plaintext = keypair
+            .decrypt(Oaep::new::<Sha256>(), &ciphertext)
+            .map_err(|e| anyhow!("RSA-OAEP decrypt CiphertextForRecipient failed: {e:?}"))?;
+
+        Ok(plaintext)
+    }
+
+    /// A `Challenge` is a fresh nonce plus a short-lived token signed by the AS, both
+    /// bound into the evidence to defeat replay.
+    async fn get_challenge(&self, credential: &StsCredential) -> anyhow::Result<Challenge> {
+        let response = self
+            .call_api(credential, "GetChallenge", BTreeMap::new())
+            .await?;
+        let nonce = response
+            .get("Nonce")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("GetChallenge response has no Nonce"))?
+            .to_string();
+        let challenge_token = response
+            .get("ChallengeToken")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("GetChallenge response has no ChallengeToken"))?
+            .to_string();
+        Ok(Challenge {
+            nonce,
+            challenge_token,
+        })
+    }
+
+    /// Build the base64url(with padding) `attestationDocument` wrapped inside a
+    /// `Recipient` JSON string, binding `keypair`'s public key into TEE evidence.
+    async fn build_recipient(
+        &self,
+        challenge: &Challenge,
+        keypair: &RsaPrivateKey,
+    ) -> anyhow::Result<String> {
+        let tee_pubkey = json!({
+            "alg": "RSA",
+            "k-exp": URL_SAFE_NO_PAD.encode(keypair.e().to_bytes_be()),
+            "k-mod": URL_SAFE_NO_PAD.encode(keypair.n().to_bytes_be()),
+        });
+        let structured = json!({
+            "challenge_token": challenge.challenge_token,
+            "nonce": challenge.nonce,
+            "tee-pubkey": tee_pubkey,
+        });
+
+        // report_data = SHA-384(canonical(structured)); the AS recomputes and compares
+        // it against the report data embedded in the quote.
+        let report_data = sha384_canonical(&structured)?;
+        let evidence = self.get_evidence(report_data).await?;
+
+        let attestation_document = json!({
+            "tee": self.tee,
+            "evidence": URL_SAFE_NO_PAD.encode(evidence),
+            "runtime_data": { "structured": structured },
+            "runtime_data_hash_algorithm": "sha384",
+        });
+        let attestation_document =
+            serde_json::to_vec(&attestation_document).context("serialize attestationDocument")?;
+
+        let recipient = json!({
+            "type": "Trustee",
+            "KeyEncryptionAlgorithm": KEY_ENCRYPTION_ALGORITHM,
+            // NOTE: base64url WITH padding, matching the KMS Trustee parser.
+            "attestationDocument": URL_SAFE.encode(attestation_document),
+        });
+        serde_json::to_string(&recipient).context("serialize Recipient")
+    }
+
+    /// Ask the attestation-agent to produce TEE evidence whose report data is
+    /// `report_data` (the canonical SHA-384 of the structured runtime data).
+    async fn get_evidence(&self, report_data: Vec<u8>) -> anyhow::Result<Vec<u8>> {
+        let client = ttrpc::r#async::Client::connect(&self.aa_socket).map_err(|e| {
+            anyhow!(
+                "connect attestation-agent at {} failed: {e}",
+                self.aa_socket
+            )
+        })?;
+        let aa = AttestationAgentServiceClient::new(client);
+        let req = GetEvidenceRequest {
+            RuntimeData: report_data,
+            ..Default::default()
+        };
+        let res = aa
+            .get_evidence(context::with_timeout(AA_TTRPC_TIMEOUT_NANOS), &req)
+            .await
+            .map_err(|e| anyhow!("get evidence from attestation-agent failed: {e}"))?;
+        Ok(res.Evidence)
+    }
+
+    async fn get_session_credential(&self) -> anyhow::Result<StsCredential> {
+        let request_url = format!(
+            "http://100.100.100.200/latest/meta-data/ram/security-credentials/{}",
+            self.ecs_ram_role_name
+        );
+        let response = reqwest::get(&request_url).await?;
+        if !response.status().is_success() {
+            bail!(
+                "request session credential from IMDS failed with status: {}",
+                response.status()
+            );
+        }
+        let body = response.text().await?;
+        let credential = serde_json::from_str(&body).context("parse IMDS STS credential")?;
+        Ok(credential)
+    }
+
+    const API_VERSION: &'static str = "2016-01-20";
+    const SIGNATURE_METHOD: &'static str = "HMAC-SHA1";
+    const SIGNATURE_VERSION: &'static str = "1.0";
+    const FORMAT: &'static str = "JSON";
+
+    /// Perform one signed POP RPC call against the dedicated instance endpoint. All
+    /// parameters (including the STS `SecurityToken`) go into the url-encoded form body.
+    async fn call_api(
+        &self,
+        credential: &StsCredential,
+        action: &str,
+        biz_params: BTreeMap<String, String>,
+    ) -> anyhow::Result<Value> {
+        let mut params = biz_params;
+        params.insert("Action".to_string(), action.to_string());
+        params.insert("Version".to_string(), Self::API_VERSION.to_string());
+        params.insert("Format".to_string(), Self::FORMAT.to_string());
+        params.insert("AccessKeyId".to_string(), credential.ak.clone());
+        params.insert("SecurityToken".to_string(), credential.sts.clone());
+        params.insert(
+            "SignatureMethod".to_string(),
+            Self::SIGNATURE_METHOD.to_string(),
+        );
+        params.insert(
+            "SignatureVersion".to_string(),
+            Self::SIGNATURE_VERSION.to_string(),
+        );
+        params.insert(
+            "Timestamp".to_string(),
+            Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+        );
+        let nonce: Vec<u8> = rand::rng().sample_iter(&Alphanumeric).take(16).collect();
+        let nonce = nonce.iter().fold(String::new(), |mut out, b| {
+            let _ = write!(out, "{b:02X}");
+            out
+        });
+        params.insert("SignatureNonce".to_string(), nonce);
+
+        // canonicalized query = sorted "k=v" joined by '&', each url-encoded (POP style)
+        let canonicalized = params
+            .iter()
+            .map(|(k, v)| {
+                format!(
+                    "{}={}",
+                    credential::urlencode_openapi(k),
+                    credential::urlencode_openapi(v)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("&");
+        let string_to_sign = format!("POST&%2F&{}", credential::urlencode_openapi(&canonicalized));
+        let signature = credential::sign(&string_to_sign, &(credential.sk.clone() + "&"))?;
+        params.insert("Signature".to_string(), signature);
+
+        let body = params
+            .iter()
+            .map(|(k, v)| {
+                format!(
+                    "{}={}",
+                    credential::urlencode_openapi(k),
+                    credential::urlencode_openapi(v)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("&");
+
+        debug!("aliyun kms attestation: calling {action}");
+        let response = self
+            .http_client
+            .post(format!("https://{}/", self.endpoint))
+            .header("Host", &self.endpoint)
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .body(body)
+            .send()
+            .await?;
+
+        let status = response.status();
+        let text = response.text().await?;
+        let value: Value = serde_json::from_str(&text)
+            .with_context(|| format!("parse {action} response as JSON: {text}"))?;
+
+        if !status.is_success() {
+            bail!(
+                "{action} failed, http status: {}, code: {}, message: {}, request id: {}",
+                status,
+                value.get("Code").and_then(Value::as_str).unwrap_or("-"),
+                value.get("Message").and_then(Value::as_str).unwrap_or("-"),
+                value
+                    .get("RequestId")
+                    .and_then(Value::as_str)
+                    .unwrap_or("-"),
+            );
+        }
+        Ok(value)
+    }
+}
+
+struct Challenge {
+    nonce: String,
+    challenge_token: String,
+}
+
+/// Serialize `value` with the same canonical JSON rules the AS uses (recursively
+/// key-sorted, compact) and return its SHA-384 digest.
+fn sha384_canonical(value: &Value) -> anyhow::Result<Vec<u8>> {
+    let mut buf = Vec::new();
+    let mut serializer =
+        serde_json::Serializer::with_formatter(&mut buf, CanonicalFormatter::new());
+    value.serialize(&mut serializer)?;
+    Ok(Sha384::digest(&buf).to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_hash_is_order_independent() {
+        let a = json!({
+            "nonce": "n",
+            "tee-pubkey": { "k-mod": "m", "alg": "RSA", "k-exp": "AQAB" },
+            "challenge_token": "t",
+        });
+        let b = json!({
+            "challenge_token": "t",
+            "tee-pubkey": { "alg": "RSA", "k-exp": "AQAB", "k-mod": "m" },
+            "nonce": "n",
+        });
+        let da = sha384_canonical(&a).unwrap();
+        let db = sha384_canonical(&b).unwrap();
+        assert_eq!(da, db);
+        assert_eq!(da.len(), 48);
+    }
+
+    #[test]
+    fn oaep_roundtrip_with_ephemeral_key() {
+        // The KMS encrypts the secret with the exported public modulus/exponent and
+        // RSAES-OAEP-SHA256; the ephemeral private key must recover it. This guards
+        // against an OAEP hash mismatch (e.g. SHA-1) breaking decryption.
+        use rsa::RsaPublicKey;
+
+        let keypair = RsaPrivateKey::new(&mut OsRng, RSA_KEY_BITS).unwrap();
+        let n = rsa::BigUint::from_bytes_be(&keypair.n().to_bytes_be());
+        let e = rsa::BigUint::from_bytes_be(&keypair.e().to_bytes_be());
+        let public = RsaPublicKey::new(n, e).unwrap();
+        assert_eq!(public.size(), RSA_KEY_BITS / 8);
+
+        let secret = b"1234567890";
+        let ciphertext = public
+            .encrypt(&mut OsRng, Oaep::new::<Sha256>(), secret)
+            .unwrap();
+        let recovered = keypair.decrypt(Oaep::new::<Sha256>(), &ciphertext).unwrap();
+        assert_eq!(recovered, secret);
+    }
+
+    #[test]
+    fn tee_pubkey_exponent_is_aqab() {
+        let keypair = RsaPrivateKey::new(&mut OsRng, RSA_KEY_BITS).unwrap();
+        assert_eq!(URL_SAFE_NO_PAD.encode(keypair.e().to_bytes_be()), "AQAB");
+    }
+}

--- a/confidential-data-hub/hub/src/kms/plugins/aliyun/client/attestation_client/mod.rs
+++ b/confidential-data-hub/hub/src/kms/plugins/aliyun/client/attestation_client/mod.rs
@@ -22,7 +22,7 @@
 //!    evidence and returns `CiphertextForRecipient` = RSA-OAEP(SHA-256)(secret)
 //! 4. decrypt `CiphertextForRecipient` with the ephemeral private key
 
-use std::{collections::BTreeMap, env, fmt::Write as _};
+use std::{collections::BTreeMap, env, fmt, fmt::Write as _};
 
 use anyhow::{anyhow, bail, Context};
 use base64::{
@@ -68,13 +68,20 @@ pub struct AliAttestationProviderSettings {
     /// KMS instance id, e.g. `kst-xxxxxx`.
     pub kms_instance_id: String,
 
-    /// Region of the KMS instance, e.g. `cn-hangzhou`. Used to fetch the ECS RAM
-    /// role session credential from IMDS.
-    pub region_id: String,
+    /// ECS RAM role bound to the instance. When configured, its temporary STS
+    /// credential is fetched from IMDS to sign the KMS requests.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ecs_ram_role_name: Option<String>,
 
-    /// ECS RAM role bound to the instance; its temporary STS credential (fetched
-    /// from IMDS) signs the KMS requests. This keeps no long-term secret in the TEE.
-    pub ecs_ram_role_name: String,
+    /// STS credential in `AK:SK:STS` format. This is an alternative to
+    /// `ecs_ram_role_name`; exactly one credential source must be configured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sts_token: Option<String>,
+
+    /// PEM-encoded private CA certificate of the KMS instance. When omitted, the
+    /// certificate is read from the in-guest credential directory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kms_ca_cert: Option<String>,
 
     /// TEE type reported in the attestation document, e.g. `tdx`. Defaults to `tdx`.
     #[serde(default = "default_tee")]
@@ -85,19 +92,47 @@ fn default_tee() -> String {
     "tdx".to_string()
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct AttestationClient {
     kms_instance_id: String,
     endpoint: String,
-    region_id: String,
-    ecs_ram_role_name: String,
+    credential_source: CredentialSource,
+    kms_ca_cert: Option<String>,
     tee: String,
     aa_socket: String,
     http_client: reqwest::Client,
 }
 
+#[derive(Clone)]
+enum CredentialSource {
+    EcsRamRole(String),
+    StsToken(StsCredential),
+}
+
+impl fmt::Debug for AttestationClient {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let credential_source = match &self.credential_source {
+            CredentialSource::EcsRamRole(_) => "ecs_ram_role",
+            CredentialSource::StsToken(_) => "sts_token",
+        };
+        f.debug_struct("AttestationClient")
+            .field("kms_instance_id", &self.kms_instance_id)
+            .field("endpoint", &self.endpoint)
+            .field("credential_source", &credential_source)
+            .field(
+                "kms_ca_cert",
+                &self.kms_ca_cert.as_ref().map(|_| "<redacted>"),
+            )
+            .field("tee", &self.tee)
+            .field("aa_socket", &self.aa_socket)
+            .field("http_client", &self.http_client)
+            .finish()
+    }
+}
+
 impl AttestationClient {
     pub fn new(settings: AliAttestationProviderSettings, cert_pem: &str) -> Result<Self> {
+        let credential_source = credential_source(&settings)?;
         let endpoint = format!(
             "{}.cryptoservice.kms.aliyuncs.com",
             settings.kms_instance_id
@@ -117,8 +152,8 @@ impl AttestationClient {
         Ok(Self {
             kms_instance_id: settings.kms_instance_id,
             endpoint,
-            region_id: settings.region_id,
-            ecs_ram_role_name: settings.ecs_ram_role_name,
+            credential_source,
+            kms_ca_cert: settings.kms_ca_cert,
             tee: settings.tee,
             aa_socket,
             http_client,
@@ -134,16 +169,7 @@ impl AttestationClient {
                 Error::AliyunKmsError(format!("parse attestation provider setting failed: {e:?}"))
             })?;
 
-        let key_path = env::var("ALIYUN_IN_GUEST_KEY_PATH")
-            .unwrap_or_else(|_| ALIYUN_IN_GUEST_DEFAULT_KEY_PATH.to_owned());
-        info!("ALIYUN_IN_GUEST_KEY_PATH = {}", key_path);
-
-        let cert_path = format!("{}/PrivateKmsCA_{}.pem", key_path, settings.kms_instance_id);
-        let cert_pem = fs::read_to_string(&cert_path).await.map_err(|e| {
-            Error::AliyunKmsError(format!(
-                "read kms instance pem cert from {cert_path} failed: {e:?}"
-            ))
-        })?;
+        let cert_pem = load_kms_ca_cert(&settings).await?;
 
         Self::new(settings, &cert_pem)
     }
@@ -152,8 +178,18 @@ impl AttestationClient {
     pub fn export_provider_settings(&self) -> Result<ProviderSettings> {
         let settings = AliAttestationProviderSettings {
             kms_instance_id: self.kms_instance_id.clone(),
-            region_id: self.region_id.clone(),
-            ecs_ram_role_name: self.ecs_ram_role_name.clone(),
+            ecs_ram_role_name: match &self.credential_source {
+                CredentialSource::EcsRamRole(name) => Some(name.clone()),
+                CredentialSource::StsToken(_) => None,
+            },
+            sts_token: match &self.credential_source {
+                CredentialSource::EcsRamRole(_) => None,
+                CredentialSource::StsToken(credential) => Some(format!(
+                    "{}:{}:{}",
+                    credential.ak, credential.sk, credential.sts
+                )),
+            },
+            kms_ca_cert: self.kms_ca_cert.clone(),
             tee: self.tee.clone(),
         };
         let provider_settings = serde_json::to_value(settings)
@@ -184,10 +220,7 @@ impl AttestationClient {
         name: &str,
         secret_settings: &AliSecretAnnotations,
     ) -> anyhow::Result<Vec<u8>> {
-        let credential = self
-            .get_session_credential()
-            .await
-            .context("get STS session credential from IMDS")?;
+        let credential = self.get_session_credential().await?;
 
         let challenge = self
             .get_challenge(&credential)
@@ -318,20 +351,25 @@ impl AttestationClient {
     }
 
     async fn get_session_credential(&self) -> anyhow::Result<StsCredential> {
-        let request_url = format!(
-            "http://100.100.100.200/latest/meta-data/ram/security-credentials/{}",
-            self.ecs_ram_role_name
-        );
-        let response = reqwest::get(&request_url).await?;
-        if !response.status().is_success() {
-            bail!(
-                "request session credential from IMDS failed with status: {}",
-                response.status()
-            );
+        match &self.credential_source {
+            CredentialSource::StsToken(credential) => Ok(credential.clone()),
+            CredentialSource::EcsRamRole(role_name) => {
+                let request_url = format!(
+                    "http://100.100.100.200/latest/meta-data/ram/security-credentials/{role_name}"
+                );
+                let response = reqwest::get(&request_url)
+                    .await
+                    .context("request STS session credential from IMDS")?;
+                if !response.status().is_success() {
+                    bail!(
+                        "request session credential from IMDS failed with status: {}",
+                        response.status()
+                    );
+                }
+                let body = response.text().await?;
+                serde_json::from_str(&body).context("parse IMDS STS credential")
+            }
         }
-        let body = response.text().await?;
-        let credential = serde_json::from_str(&body).context("parse IMDS STS credential")?;
-        Ok(credential)
     }
 
     const API_VERSION: &'static str = "2016-01-20";
@@ -436,6 +474,66 @@ struct Challenge {
     challenge_token: String,
 }
 
+fn credential_source(settings: &AliAttestationProviderSettings) -> Result<CredentialSource> {
+    match (
+        settings
+            .ecs_ram_role_name
+            .as_deref()
+            .filter(|name| !name.trim().is_empty()),
+        settings
+            .sts_token
+            .as_deref()
+            .filter(|token| !token.trim().is_empty()),
+    ) {
+        (Some(role_name), None) => Ok(CredentialSource::EcsRamRole(role_name.to_owned())),
+        (None, Some(token)) => parse_sts_token(token).map(CredentialSource::StsToken),
+        (Some(_), Some(_)) => Err(Error::AliyunKmsError(
+            "only one of ecs_ram_role_name and sts_token can be configured".to_string(),
+        )),
+        (None, None) => Err(Error::AliyunKmsError(
+            "one of ecs_ram_role_name and sts_token must be configured".to_string(),
+        )),
+    }
+}
+
+fn parse_sts_token(token: &str) -> Result<StsCredential> {
+    let mut sections = token.splitn(3, ':');
+    let ak = sections.next().unwrap_or_default();
+    let sk = sections.next().unwrap_or_default();
+    let sts = sections.next().unwrap_or_default();
+    if ak.is_empty() || sk.is_empty() || sts.is_empty() {
+        return Err(Error::AliyunKmsError(
+            "invalid sts_token format, expected AK:SK:STS".to_string(),
+        ));
+    }
+    Ok(StsCredential {
+        ak: ak.to_owned(),
+        sk: sk.to_owned(),
+        sts: sts.to_owned(),
+    })
+}
+
+async fn load_kms_ca_cert(settings: &AliAttestationProviderSettings) -> Result<String> {
+    if let Some(cert) = settings
+        .kms_ca_cert
+        .as_deref()
+        .filter(|cert| !cert.trim().is_empty())
+    {
+        return Ok(cert.to_owned());
+    }
+
+    let key_path = env::var("ALIYUN_IN_GUEST_KEY_PATH")
+        .unwrap_or_else(|_| ALIYUN_IN_GUEST_DEFAULT_KEY_PATH.to_owned());
+    info!("ALIYUN_IN_GUEST_KEY_PATH = {}", key_path);
+
+    let cert_path = format!("{}/PrivateKmsCA_{}.pem", key_path, settings.kms_instance_id);
+    fs::read_to_string(&cert_path).await.map_err(|e| {
+        Error::AliyunKmsError(format!(
+            "read kms instance pem cert from {cert_path} failed: {e:?}"
+        ))
+    })
+}
+
 /// Serialize `value` with the same canonical JSON rules the AS uses (recursively
 /// key-sorted, compact) and return its SHA-384 digest.
 fn sha384_canonical(value: &Value) -> anyhow::Result<Vec<u8>> {
@@ -493,5 +591,52 @@ mod tests {
     fn tee_pubkey_exponent_is_aqab() {
         let keypair = RsaPrivateKey::new(&mut OsRng, RSA_KEY_BITS).unwrap();
         assert_eq!(URL_SAFE_NO_PAD.encode(keypair.e().to_bytes_be()), "AQAB");
+    }
+
+    #[test]
+    fn parse_direct_sts_token() {
+        let credential = parse_sts_token("ak:sk:sts:with:colons").unwrap();
+        assert_eq!(credential.ak, "ak");
+        assert_eq!(credential.sk, "sk");
+        assert_eq!(credential.sts, "sts:with:colons");
+    }
+
+    #[test]
+    fn credential_source_must_be_unambiguous() {
+        let settings = AliAttestationProviderSettings {
+            kms_instance_id: "kst-test".to_string(),
+            ecs_ram_role_name: Some("test-role".to_string()),
+            sts_token: Some("ak:sk:sts".to_string()),
+            kms_ca_cert: None,
+            tee: default_tee(),
+        };
+        assert!(credential_source(&settings).is_err());
+    }
+
+    #[tokio::test]
+    async fn embedded_ca_cert_takes_precedence_over_file() {
+        let settings = AliAttestationProviderSettings {
+            kms_instance_id: "kst-test".to_string(),
+            ecs_ram_role_name: Some("test-role".to_string()),
+            sts_token: None,
+            kms_ca_cert: Some("-----BEGIN CERTIFICATE-----\ninline\n".to_string()),
+            tee: default_tee(),
+        };
+        assert_eq!(
+            load_kms_ca_cert(&settings).await.unwrap(),
+            "-----BEGIN CERTIFICATE-----\ninline\n"
+        );
+    }
+
+    #[test]
+    fn legacy_region_id_is_ignored() {
+        let settings: AliAttestationProviderSettings = serde_json::from_value(json!({
+            "kms_instance_id": "kst-test",
+            "region_id": "cn-hangzhou",
+            "ecs_ram_role_name": "test-role"
+        }))
+        .unwrap();
+        assert_eq!(settings.kms_instance_id, "kst-test");
+        assert_eq!(settings.ecs_ram_role_name.as_deref(), Some("test-role"));
     }
 }

--- a/confidential-data-hub/hub/src/kms/plugins/aliyun/client/mod.rs
+++ b/confidential-data-hub/hub/src/kms/plugins/aliyun/client/mod.rs
@@ -9,6 +9,7 @@ use oidc_with_ram::OidcRamClient;
 use serde_json::json;
 use sts_token_client::StsTokenClient;
 
+mod attestation_client;
 mod client_key_client;
 mod ecs_ram_role_client;
 pub mod oidc_with_ram;
@@ -18,6 +19,7 @@ use crate::kms::plugins::_IN_GUEST_DEFAULT_KEY_PATH;
 use crate::kms::{Annotations, Decrypter, Encrypter, Getter, ProviderSettings};
 use crate::kms::{Error, Result};
 
+use attestation_client::AttestationClient;
 use client_key_client::ClientKeyClient;
 use ecs_ram_role_client::EcsRamRoleClient;
 
@@ -34,6 +36,11 @@ pub enum AliyunKmsClient {
     },
     OidcRam {
         client: OidcRamClient,
+    },
+    /// Fetch confidential resources from a KMS instance with the Trustee
+    /// Attestation Service integrated, authorized by TEE remote attestation.
+    Attestation {
+        client: AttestationClient,
     },
 }
 
@@ -121,6 +128,15 @@ impl AliyunKmsClient {
                     ))
                 })?,
             },
+            "attestation" => AliyunKmsClient::Attestation {
+                client: AttestationClient::from_provider_settings(provider_settings)
+                    .await
+                    .map_err(|e| {
+                        Error::AliyunKmsError(format!(
+                            "build AttestationClient with `from_provider_settings()` failed: {e}"
+                        ))
+                    })?,
+            },
             _ => return Err(Error::AliyunKmsError("client type invalid.".to_string())),
         };
 
@@ -170,6 +186,17 @@ impl AliyunKmsClient {
 
                 Ok(provider_settings)
             }
+            AliyunKmsClient::Attestation { client } => {
+                let mut provider_settings = client.export_provider_settings().map_err(|e| {
+                    Error::AliyunKmsError(format!(
+                        "AttestationClient `export_provider_settings()` failed: {e}"
+                    ))
+                })?;
+
+                provider_settings.insert(String::from("client_type"), json!("attestation"));
+
+                Ok(provider_settings)
+            }
         }
     }
 }
@@ -187,6 +214,9 @@ impl Encrypter for AliyunKmsClient {
             )),
             AliyunKmsClient::OidcRam { .. } => Err(Error::AliyunKmsError(
                 "Encrypter does not support accessing through Aliyun OidcRam".to_string(),
+            )),
+            AliyunKmsClient::Attestation { .. } => Err(Error::AliyunKmsError(
+                "Encrypter does not support accessing through Aliyun Attestation".to_string(),
             )),
         }
     }
@@ -213,6 +243,9 @@ impl Decrypter for AliyunKmsClient {
             AliyunKmsClient::OidcRam { .. } => Err(Error::AliyunKmsError(
                 "Decrypter does not support accessing through Aliyun OidcRam".to_string(),
             )),
+            AliyunKmsClient::Attestation { .. } => Err(Error::AliyunKmsError(
+                "Decrypter does not support accessing through Aliyun Attestation".to_string(),
+            )),
         }
     }
 }
@@ -230,6 +263,9 @@ impl Getter for AliyunKmsClient {
                 .get_secret(name, annotations)
                 .await
                 .map_err(|e| Error::AliyunKmsError(format!("failed to get secret: {e:#?}"))),
+            AliyunKmsClient::Attestation { ref client } => {
+                client.get_secret(name, annotations).await
+            }
         }
     }
 }

--- a/confidential-data-hub/hub/src/kms/plugins/aliyun/client/sts_token_client/credential.rs
+++ b/confidential-data-hub/hub/src/kms/plugins/aliyun/client/sts_token_client/credential.rs
@@ -11,7 +11,7 @@ use ring::hmac::{self, Key, HMAC_SHA1_FOR_LEGACY_USE_ONLY};
 use serde::Deserialize;
 use url::form_urlencoded::byte_serialize;
 
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct StsCredential {
     #[serde(rename = "AccessKeyId")]
     pub ak: String,


### PR DESCRIPTION
## What this PR does

Adds a new `attestation` client type to the aliyun KMS plugin in
confidential-data-hub. It lets a confidential guest fetch confidential
resources (KMS secrets) from an Aliyun KMS instance that has the Trustee
Attestation Service integrated. The KMS authorizes the request with TEE remote
attestation and encrypts the result to an ephemeral key bound into the evidence.

The attestation client supports two CA sources and two STS credential sources:

- KMS private CA embedded in `provider_settings`, or loaded from the existing
  in-guest credential file as a backward-compatible fallback.
- A directly configured short-lived STS credential, or an ECS RAM role whose
  STS credential is fetched from IMDS.

## Background

Besides serving secrets over the RCAR protocol from a standalone Trustee KBS,
the Trustee Attestation Service can now be integrated inside an Aliyun KMS
instance. In that model the KMS itself verifies the TEE evidence and returns
the secret encrypted to a public key that is bound into the evidence, so the
plaintext is only recoverable inside the attested TEE. This client implements
the guest side of that flow.

## How it works

All requests are RPC-style `POST /` form bodies signed with the Aliyun POP
HMAC-SHA1 scheme, sent to the dedicated instance endpoint
(`{instance}.cryptoservice.kms.aliyuncs.com`) over its private CA.

1. Use the STS credential configured in the sealed secret, or fetch a temporary
   STS credential from the configured ECS RAM role via IMDS.
2. `GetChallenge` → `{ Nonce, ChallengeToken }`.
3. Generate an ephemeral RSA-2048 key pair, build the `structured` runtime
   data `{ challenge_token, nonce, tee-pubkey }`, hash it canonically with
   SHA-384 (via `canon-json`, matching the AS), and let the attestation-agent
   embed the hash into the TEE evidence report data.
4. `GetSecretValue` with a Trustee `Recipient` carrying the evidence; the KMS
   verifies it and returns `CiphertextForRecipient` = RSAES-OAEP-SHA256(secret).
5. Decrypt `CiphertextForRecipient` with the ephemeral private key.

## Integration

The client plugs into the existing vault sealed-secret `Getter` path, so no
routing change is needed. A Vault secret whose provider is `aliyun` and whose
provider settings carry `client_type: "attestation"` is served by this client.

Use an ECS RAM role and the existing CA file layout:

```json
{
  "client_type": "attestation",
  "kms_instance_id": "kst-xxxxxxxx",
  "ecs_ram_role_name": "your-ecs-ram-role"
}
```

The CA fallback path is
`{ALIYUN_IN_GUEST_KEY_PATH}/PrivateKmsCA_{instance}.pem`.

Alternatively, embed the KMS CA and use a short-lived STS credential directly:

```json
{
  "client_type": "attestation",
  "kms_instance_id": "kst-xxxxxxxx",
  "sts_token": "<AccessKeyId>:<AccessKeySecret>:<SecurityToken>",
  "kms_ca_cert": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n"
}
```

Exactly one of `ecs_ram_role_name` and `sts_token` must be configured. When
`kms_ca_cert` is present, CDH does not read a CA file. Direct STS credentials
are stored in the sealed secret provider settings, so callers should use only
short-lived credentials and protect the sealed secret from unauthorized access.

`secret unseal` no longer requires `--key-path` when all Aliyun client material
needed by the selected mode is embedded in provider settings.

`region_id` is not required by this client. The dedicated KMS endpoint is
derived from the globally unique `kms_instance_id`; IMDS and POP requests do
not use a region parameter. Legacy provider settings that still contain
`region_id` remain compatible because the unknown field is ignored.

## Testing

- Rust 1.76 formatting, seven attestation-client unit tests, default-feature
  `cargo check`, release build, and Clippy with warnings denied all pass.
- Unit coverage includes canonical JSON, RSAES-OAEP-SHA256, RSA public-key
  encoding, direct STS parsing, mutually exclusive credential sources, and
  embedded-CA precedence, and legacy `region_id` compatibility.
- End-to-end on a real Intel TDX ECS instance against a real KMS instance with
  the integrated Trustee Attestation Service passed without `region_id` for
  all three modes:
  - CA file + ECS RAM role (backward compatibility)
  - embedded CA + ECS RAM role
  - embedded CA + directly configured STS credential

## Note on the OAEP backend

The ephemeral key uses the `rsa` crate directly to guarantee OAEP with SHA-256
for both the digest and MGF1. The shared `crypto` crate's OpenSSL backend still
maps `PaddingMode::OAEP` to OpenSSL's default (SHA-1) OAEP, which would not
interoperate with the KMS `RSAES_OAEP_SHA_256` wrapping.
