### PR TITLE
Release v1.5.2

### DIFF
--- a/APPLICATION/attestation-agent/buildspec.yml
+++ b/APPLICATION/attestation-agent/buildspec.yml
@@ -30,7 +30,7 @@ images:
       path: Dockerfile.aa
       scene:
         args: []
-        tags: [[1.5.1, latest]]
+        tags: [[1.5.2, latest]]
         registry: [*ACR_PROD]
       # 测试配置
       test_config: [*WORKSPACE, *PROJECT, *TEST_SUITE, *TEST_CONF, *TEST_CASE, *CLOUD_SERVER_TAG[0], '']

--- a/APPLICATION/confidential-data-hub/buildspec.yml
+++ b/APPLICATION/confidential-data-hub/buildspec.yml
@@ -30,7 +30,7 @@ images:
       path: Dockerfile.cdh
       scene:
         args: []
-        tags: [[1.5.1, latest]]
+        tags: [[1.5.2, latest]]
         registry: [*ACR_PROD]
       # 测试配置
       test_config: [*WORKSPACE, *PROJECT, *TEST_SUITE, *TEST_CONF, *TEST_CASE, *CLOUD_SERVER_TAG[0], '']

--- a/APPLICATION/trustiflux-api-server/buildspec.yml
+++ b/APPLICATION/trustiflux-api-server/buildspec.yml
@@ -30,7 +30,7 @@ images:
       path: Dockerfile.api
       scene:
         args: []
-        tags: [[1.5.1, latest]]
+        tags: [[1.5.2, latest]]
         registry: [*ACR_PROD]
       # 测试配置
       test_config: [*WORKSPACE, *PROJECT, *TEST_SUITE, *TEST_CONF, *TEST_CASE, *CLOUD_SERVER_TAG[0], '']

--- a/Dockerfile.aa
+++ b/Dockerfile.aa
@@ -23,14 +23,16 @@ RUN case "$TARGETARCH" in \
     esac
 
 WORKDIR /tmp
-RUN yum install -y perl wget curl clang openssl-devel protobuf-devel git libudev-devel perl-FindBin
+# The AnolisOS 23 kernel-6 repository was retired from the mirrors. This image
+# does not consume kernel packages, so disable the stale repository explicitly.
+RUN yum install -y --disablerepo=kernel-6 ca-certificates perl wget curl clang openssl-devel protobuf-devel git libudev-devel perl-FindBin
 
 RUN if [ "$TARGETARCH" != "arm64" ]; then \
     curl https://download.01.org/intel-sgx/sgx-dcap/1.21/linux/distro/Anolis86/sgx_rpm_local_repo.tgz --output sgx_rpm_local_repo.tgz && \
     tar zxvf sgx_rpm_local_repo.tgz && \
     find /etc/yum.repos.d/ -type f -exec sed -i 's/http:\/\/mirrors.openanolis.cn\/anolis/https:\/\/mirrors.aliyun.com\/anolis/g' {} + && \
-    yum -y install yum-utils && yum-config-manager --add-repo file:///tmp/sgx_rpm_local_repo && \
-    yum install -y --setopt=install_weak_deps=False --nogpgcheck libtdx-attest-devel && \
+    yum install -y --disablerepo=kernel-6 yum-utils && yum-config-manager --add-repo file:///tmp/sgx_rpm_local_repo && \
+    yum install -y --disablerepo=kernel-6 --setopt=install_weak_deps=False --nogpgcheck libtdx-attest-devel && \
     yum clean all && \
     rm -rf /tmp/sgx_rpm_local_repo*; \
     fi
@@ -84,10 +86,11 @@ ARG TARGETARCH
 
 WORKDIR /tmp
 RUN if [ "$TARGETARCH" != "arm64" ]; then \
+    yum install -y --disablerepo=kernel-6 ca-certificates && \
     curl https://download.01.org/intel-sgx/sgx-dcap/1.21/linux/distro/Anolis86/sgx_rpm_local_repo.tgz --output sgx_rpm_local_repo.tgz && \
     tar zxvf sgx_rpm_local_repo.tgz && \
-    yum -y install yum-utils && yum-config-manager --add-repo file:///tmp/sgx_rpm_local_repo && \
-    yum install -y --setopt=install_weak_deps=False --nogpgcheck libtdx-attest-devel && \
+    yum install -y --disablerepo=kernel-6 yum-utils && yum-config-manager --add-repo file:///tmp/sgx_rpm_local_repo && \
+    yum install -y --disablerepo=kernel-6 --setopt=install_weak_deps=False --nogpgcheck libtdx-attest-devel && \
     yum clean all && \
     rm -rf /tmp/*; \
     fi

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -10,9 +10,12 @@ ENV NO_PROXY=$NO_PROXY
 WORKDIR /usr/src/guest-components
 COPY . .
 
-RUN yum -y install yum-utils && \
-    yum install -y --setopt=install_weak_deps=False --nogpgcheck \
+# The AnolisOS 23 kernel-6 repository was retired from the mirrors. This image
+# does not consume kernel packages, so disable the stale repository explicitly.
+RUN yum install -y --disablerepo=kernel-6 yum-utils && \
+    yum install -y --disablerepo=kernel-6 --setopt=install_weak_deps=False --nogpgcheck \
         clang \
+        ca-certificates \
         protobuf-devel \
         git \
         curl \
@@ -43,7 +46,7 @@ RUN if [ -n "${ALL_PROXY}" ]; then \
 RUN cargo +1.79.0 build -p api-server-rest --release --locked
 
 FROM registry.openanolis.cn/openanolis/anolisos:23.2
-RUN yum install -y --setopt=install_weak_deps=False --nogpgcheck ca-certificates && \
+RUN yum install -y --disablerepo=kernel-6 --setopt=install_weak_deps=False --nogpgcheck ca-certificates && \
     yum clean all && \
     rm -rf /tmp/*
 
@@ -54,4 +57,3 @@ COPY dist/rpm/trustiflux-api-server.toml /etc/trustiflux/trustiflux-api-server.t
 EXPOSE 8006
 ENTRYPOINT ["/usr/local/bin/trustiflux-api-server"]
 CMD ["--config", "/etc/trustiflux/trustiflux-api-server.toml"]
-

--- a/trustiflux.spec
+++ b/trustiflux.spec
@@ -3,7 +3,7 @@
 %global libdir /usr/lib
 
 Name:		trustiflux
-Version:	1.5.1
+Version:	1.5.2
 Release:	%{release}%{?dist}
 Summary:	A daemon service running inside TEE (Trusted Execution Environment) to confidential resource related APIs
 
@@ -137,6 +137,15 @@ rm -rf %{buildroot}
 %{libdir}/dracut/modules.d/99confidential-data-hub/module-setup.sh
 
 %changelog
+* Wed Jul 29 2026 Jiale Zhang <zhangjiale@linux.alibaba.com> - 1.5.2-1
+- Attestation: add pure-Go attester and attestation-agent libraries
+- CDH: add Aliyun KMS remote-attestation client and configuration improvements
+- KBS protocol: align end-to-end tests with the current KBS configuration
+- Initdata processor: add AAEL support and move under attestation-agent
+- Image pull: add benchmarks and kernel command-line configuration
+- Hygon TPM: align SM2 AK parameters and canonicalize Keylime UUIDs
+- Build: fix minimal attester feature combinations
+
 * Mon May 18 2026 Jiale Zhang <xinjian.zjl@alibaba-inc.com> - 1.5.1-1
 - Attester: add Hygon TPM tee type with sm2/sm3 keylime support
 - Test: gate live image verification cases behind opt-in env

--- a/trustiflux.spec
+++ b/trustiflux.spec
@@ -145,6 +145,7 @@ rm -rf %{buildroot}
 - Image pull: add benchmarks and kernel command-line configuration
 - Hygon TPM: align SM2 AK parameters and canonicalize Keylime UUIDs
 - Build: fix minimal attester feature combinations
+- Containers: handle the retired AnolisOS kernel-6 repository and refresh CA certificates
 
 * Mon May 18 2026 Jiale Zhang <xinjian.zjl@alibaba-inc.com> - 1.5.1-1
 - Attester: add Hygon TPM tee type with sm2/sm3 keylime support


### PR DESCRIPTION
## Summary

- bump the Trustiflux RPM version from 1.5.1 to 1.5.2
- update the attestation-agent, confidential-data-hub, and trustiflux-api-server image tags to 1.5.2
- add the 1.5.2 RPM changelog entry covering changes since v1.5.1
- make AnolisOS-based image builds tolerate the retired `kernel-6` repository
- refresh CA certificates before HTTPS downloads from the older AnolisOS 23.2 base image

## Release scope

This release includes the changes merged after v1.5.1, notably:

- pure-Go attester and attestation-agent libraries
- Aliyun KMS remote-attestation client improvements
- KBS protocol test compatibility with the current KBS configuration
- initdata processor AAEL support
- image pull benchmarks and kernel command-line configuration
- Hygon TPM SM2/Keylime UUID fixes
- minimal attester feature-set build fixes

## Validation

- `rpmspec --parse trustiflux.spec`
- release version consistency check across the RPM spec and three image buildspecs
- `cargo metadata --locked --no-deps --format-version 1`
- `git diff --check`
- reproduced the original `kernel-6` repomd HTTP 404 with the exact AnolisOS 23.2 image digest
- validated every AA/API yum path with `kernel-6` disabled
- validated the AA builder/runtime CA refresh and Intel DCAP repository download
- completed a local proxy-backed `Dockerfile.api` image build and container smoke test
- validated the full CDH Debian apt dependency-install path; no equivalent repository issue was found
