### PR TITLE
attestation-agent: support SVSM vTPM measurements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,6 +394,7 @@ dependencies = [
  "az-snp-vtpm",
  "az-tdx-vtpm",
  "base64 0.22.1",
+ "bincode",
  "chrono",
  "clap 4.2.7",
  "codicon",

--- a/attestation-agent/README.md
+++ b/attestation-agent/README.md
@@ -134,6 +134,13 @@ VMPL0 report.
 already been activated and registered with Keylime and registrar-side AK/EK
 binding verification is required.
 
+The same build remains compatible with a plain SEV-SNP guest that does not run
+SVSM. In that environment AA emits ordinary SNP evidence and no additional TPM
+evidence. If runtime event logging is enabled in the configuration but the
+guest exposes neither an RTMR nor an SVSM vTPM, AA logs a warning and keeps
+basic remote attestation available; runtime measurement extension requests
+return an explicit error.
+
 To build AA with all available attesters and install, use
 ```shell
 make ATTESTER=all-attesters && make install

--- a/attestation-agent/README.md
+++ b/attestation-agent/README.md
@@ -120,6 +120,20 @@ AA supports different kinds of hardware TEE attesters, now
 | cca-attester        | Arm Confidential Compute Architecture (CCA)  |
 | se-attester         | IBM Secure Execution (SE)   |
 
+#### SEV-SNP with an SVSM vTPM
+
+On a guest with the Linux `tpm_svsm` driver and the TSM SVSM attestation ABI,
+the SNP attester automatically collects a VMPL0 SNP report and the Coconut
+vTPM service manifest. The TPM is added as device evidence, and AA runtime
+events are extended into its PCRs even though SNP remains the primary
+attester. The composite KBS evidence binds the TPM quote to the SNP challenge;
+the verifier can additionally bind the vTPM EK to the manifest covered by the
+VMPL0 report.
+
+`KEYLIME_AGENT_UUID` remains optional. Set it only when the generated AK has
+already been activated and registered with Keylime and registrar-side AK/EK
+binding verification is required.
+
 To build AA with all available attesters and install, use
 ```shell
 make ATTESTER=all-attesters && make install

--- a/attestation-agent/attestation-agent/src/lib.rs
+++ b/attestation-agent/attestation-agent/src/lib.rs
@@ -92,7 +92,7 @@ pub struct AttestationAgent {
     eventlog: Option<Mutex<EventLog>>,
     initdata: Option<String>,
     primary_attester: Arc<BoxedAttester>,
-    additional_attesters: HashMap<Tee, BoxedAttester>,
+    additional_attesters: HashMap<Tee, Arc<BoxedAttester>>,
 }
 
 impl AttestationAgent {
@@ -128,11 +128,20 @@ impl AttestationAgent {
         }
 
         if config.eventlog_config.enable_eventlog {
-            let eventlog = EventLog::new(
-                self.primary_attester.clone(),
-                config.eventlog_config.init_pcr,
-            )
-            .await?;
+            let rtmr_extender = if self.primary_attester.supports_runtime_measurement() {
+                self.primary_attester.clone()
+            } else {
+                self.additional_attesters
+                    .values()
+                    .find(|attester| attester.supports_runtime_measurement())
+                    .cloned()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Runtime eventlog is enabled, but neither the primary nor an additional attester supports runtime measurement"
+                        )
+                    })?
+            };
+            let eventlog = EventLog::new(rtmr_extender, config.eventlog_config.init_pcr).await?;
 
             self.eventlog = Some(Mutex::new(eventlog));
         }
@@ -159,7 +168,7 @@ impl AttestationAgent {
 
         let mut additional_attesters = HashMap::new();
         for tee in additional_tees {
-            additional_attesters.insert(tee, tee.try_into()?);
+            additional_attesters.insert(tee, Arc::new(tee.try_into()?));
         }
 
         Ok(AttestationAgent {

--- a/attestation-agent/attestation-agent/src/lib.rs
+++ b/attestation-agent/attestation-agent/src/lib.rs
@@ -129,21 +129,23 @@ impl AttestationAgent {
 
         if config.eventlog_config.enable_eventlog {
             let rtmr_extender = if self.primary_attester.supports_runtime_measurement() {
-                self.primary_attester.clone()
+                Some(self.primary_attester.clone())
             } else {
                 self.additional_attesters
                     .values()
                     .find(|attester| attester.supports_runtime_measurement())
                     .cloned()
-                    .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "Runtime eventlog is enabled, but neither the primary nor an additional attester supports runtime measurement"
-                        )
-                    })?
             };
-            let eventlog = EventLog::new(rtmr_extender, config.eventlog_config.init_pcr).await?;
 
-            self.eventlog = Some(Mutex::new(eventlog));
+            if let Some(rtmr_extender) = rtmr_extender {
+                let eventlog =
+                    EventLog::new(rtmr_extender, config.eventlog_config.init_pcr).await?;
+                self.eventlog = Some(Mutex::new(eventlog));
+            } else {
+                warn!(
+                    "Runtime eventlog is enabled, but this platform has no runtime measurement backend; continuing with remote attestation without dynamic measurements"
+                );
+            }
         }
 
         Ok(())
@@ -339,5 +341,22 @@ mod tests {
         // In test environment, the aliyun_ecs module should fail gracefully
         // and either not set the env var or set it to None/empty
         // Let's just verify the init() call completes successfully
+    }
+
+    #[tokio::test]
+    async fn test_eventlog_without_measurement_backend_degrades_gracefully() {
+        let mut aa = AttestationAgent::new(None).unwrap();
+        aa.config.write().await.eventlog_config.enable_eventlog = true;
+
+        aa.init()
+            .await
+            .expect("remote attestation must remain available without an RTMR or TPM");
+
+        assert!(aa.eventlog.is_none());
+        assert!(aa.get_evidence(&[0; 64]).await.is_ok());
+        assert!(aa
+            .extend_runtime_measurement("domain", "operation", "content", None)
+            .await
+            .is_err());
     }
 }

--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -15,6 +15,7 @@ az-tdx-vtpm = { version = "0.7.0", default-features = false, features = [
     "attester",
 ], optional = true }
 base64.workspace = true
+bincode.workspace = true
 clap = { workspace = true, features = ["derive"], optional = true }
 eventlog-rs = { version = "0.1.8", optional = true }
 hex.workspace = true
@@ -58,6 +59,7 @@ chrono = { workspace = true, features = ["serde"], optional = true }
 [dev-dependencies]
 tokio.workspace = true
 rstest.workspace = true
+tempfile.workspace = true
 
 [[bin]]
 name = "evidence_getter"
@@ -95,7 +97,7 @@ gpu-attester = ["nvml-wrapper", "uuid", "chrono"]
 sgx-attester = ["occlum_dcap"]
 az-snp-vtpm-attester = ["az-snp-vtpm"]
 az-tdx-vtpm-attester = ["az-snp-vtpm-attester", "az-tdx-vtpm"]
-snp-attester = ["sev"]
+snp-attester = ["sev", "tsm-report"]
 csv-attester = ["hygon", "codicon", "hyper", "hyper-tls"]
 hygon-dcu-attester = ["hygon"]
 hygon = ["csv-rs"]

--- a/attestation-agent/attester/src/lib.rs
+++ b/attestation-agent/attester/src/lib.rs
@@ -104,6 +104,13 @@ pub trait Attester {
     /// evidence to avoid reply attack.
     async fn get_evidence(&self, report_data: Vec<u8>) -> Result<TeeEvidence>;
 
+    /// Whether this attester can extend and read a runtime measurement
+    /// register. Callers use this to select a measurement backend without
+    /// assuming that the primary TEE implements one.
+    fn supports_runtime_measurement(&self) -> bool {
+        false
+    }
+
     /// Extend TEE specific dynamic measurement register
     /// to enable dynamic measurement capabilities for input data at runtime.
     async fn extend_runtime_measurement(
@@ -228,6 +235,20 @@ pub fn detect_attestable_devices() -> Vec<Tee> {
     #[cfg(feature = "hygon-dcu-attester")]
     if hygon_dcu::detect_platform() {
         additional_devices.push(Tee::HygonDcu);
+    }
+
+    // In an SNP guest, only accept a TPM exposed by the in-guest SVSM driver.
+    // A generic or host-provided vTPM is not cryptographically rooted in the
+    // VMPL0 SNP report and must not silently become additional evidence.
+    #[cfg(all(feature = "snp-attester", feature = "tpm-attester"))]
+    if detect_tee_type() == Tee::Snp && tpm::detect_platform() {
+        if tpm::is_svsm_vtpm() {
+            additional_devices.push(Tee::Tpm);
+        } else {
+            log::warn!(
+                "A TPM was detected in the SNP guest, but its driver is not tpm-svsm; ignoring unbound TPM evidence"
+            );
+        }
     }
 
     additional_devices

--- a/attestation-agent/attester/src/snp/mod.rs
+++ b/attestation-agent/attester/src/snp/mod.rs
@@ -6,8 +6,12 @@
 use crate::utils::pad;
 use crate::InitDataResult;
 
+#[cfg(feature = "tsm-report")]
+use crate::tsm_report::{TsmReportData, TsmReportPath, TsmReportProvider};
+
 use super::{Attester, TeeEvidence};
 use anyhow::*;
+use base64::{engine::general_purpose::STANDARD, Engine};
 use serde::{Deserialize, Serialize};
 use sev::firmware::guest::AttestationReport;
 use sev::firmware::guest::Firmware;
@@ -15,6 +19,8 @@ use sev::firmware::host::CertTableEntry;
 use std::path::Path;
 
 mod hostdata;
+
+const SVSM_VTPM_SERVICE_GUID: &str = "c476f1eb-0123-45a5-9641-b4e7dde5bfe3";
 
 pub fn detect_platform() -> bool {
     Path::new("/sys/devices/platform/sev-guest").exists()
@@ -24,6 +30,10 @@ pub fn detect_platform() -> bool {
 struct SnpEvidence {
     attestation_report: AttestationReport,
     cert_chain: Option<Vec<CertTableEntry>>,
+    /// Base64-encoded SVSM vTPM manifest (manifest version 0 is the EK
+    /// TPMT_PUBLIC). The VMPL0 report binds SHA-512(nonce || manifest).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    svsm_manifest: Option<String>,
 }
 
 #[derive(Debug, Default)]
@@ -38,6 +48,50 @@ impl Attester for SnpAttester {
 
         report_data.resize(64, 0);
 
+        #[cfg(feature = "tsm-report")]
+        if let std::result::Result::Ok(tsm) = TsmReportPath::new(TsmReportProvider::Sev) {
+            if tsm.supports_svsm_attestation() {
+                let report_bytes = tsm
+                    .attestation_report(TsmReportData::SevSvsm {
+                        inblob: report_data,
+                        service_guid: SVSM_VTPM_SERVICE_GUID.to_string(),
+                        manifest_version: 0,
+                    })
+                    .context("Failed to get VMPL0 SNP report from SVSM")?;
+                let attestation_report: AttestationReport = bincode::deserialize(&report_bytes)
+                    .context("Failed to parse the SNP report returned by SVSM")?;
+
+                let manifest = tsm
+                    .manifest_data()
+                    .context("Failed to read the SVSM vTPM manifest")?;
+                if manifest.is_empty() {
+                    bail!("SVSM returned an empty vTPM manifest");
+                }
+
+                let mut cert_bytes = tsm
+                    .supplemental_data()
+                    .context("Failed to read the SNP certificate table returned by SVSM")?;
+                let cert_chain = if cert_bytes.is_empty() {
+                    None
+                } else {
+                    Some(
+                        CertTableEntry::vec_bytes_to_cert_table(&mut cert_bytes).context(
+                            "Failed to parse the SNP certificate table returned by SVSM",
+                        )?,
+                    )
+                };
+
+                let evidence = SnpEvidence {
+                    attestation_report,
+                    cert_chain,
+                    svsm_manifest: Some(STANDARD.encode(manifest)),
+                };
+
+                return serde_json::to_value(evidence)
+                    .context("Serialize SVSM-backed SNP evidence failed");
+            }
+        }
+
         let mut firmware = Firmware::open()?;
         let data = report_data.as_slice().try_into()?;
 
@@ -48,6 +102,7 @@ impl Attester for SnpAttester {
         let evidence = SnpEvidence {
             attestation_report: report,
             cert_chain: certs,
+            svsm_manifest: None,
         };
 
         serde_json::to_value(evidence).context("Serialize SNP evidence failed")

--- a/attestation-agent/attester/src/tpm/mod.rs
+++ b/attestation-agent/attester/src/tpm/mod.rs
@@ -4,7 +4,7 @@
 //
 use crate::tpm::utils::*;
 use crate::types::TpmEvidence;
-use crate::utils::read_eventlog;
+use crate::utils::read_aa_eventlog;
 use crate::{Attester, TeeEvidence};
 use anyhow::*;
 use base64::Engine;
@@ -21,6 +21,7 @@ use tss_esapi::traits::UnMarshall;
 mod utils;
 
 const TPM_EVENTLOG_FILE_PATH: &str = "/sys/kernel/security/tpm0/binary_bios_measurements";
+const TPM_SYSFS_DEVICE_PATH: &str = "/sys/class/tpm/tpm0/device";
 const TPM_REPORT_DATA_SIZE: usize = 32;
 
 const KEYLIME_AGENT_UUID_ENV: &str = "KEYLIME_AGENT_UUID";
@@ -44,7 +45,28 @@ fn try_get_keylime_uuid() -> Option<String> {
 }
 
 pub fn detect_platform() -> bool {
-    Path::new("/dev/tpm0").exists()
+    Path::new("/dev/tpm0").exists() || Path::new("/dev/tpmrm0").exists()
+}
+
+fn is_svsm_vtpm_device(device_path: &Path) -> bool {
+    if std::fs::read_to_string(device_path.join("modalias"))
+        .map(|v| v.trim() == "platform:tpm-svsm")
+        .unwrap_or(false)
+    {
+        return true;
+    }
+
+    std::fs::read_link(device_path.join("driver"))
+        .ok()
+        .and_then(|p| p.file_name().map(|n| n == "tpm-svsm"))
+        .unwrap_or(false)
+}
+
+/// Return true only for the TPM device exported by the Linux `tpm_svsm`
+/// driver. This excludes host-injected swtpm devices from SNP composite
+/// evidence.
+pub fn is_svsm_vtpm() -> bool {
+    is_svsm_vtpm_device(Path::new(TPM_SYSFS_DEVICE_PATH))
 }
 
 #[derive(Debug, Default)]
@@ -62,6 +84,13 @@ impl Attester for TpmAttester {
             report_data.truncate(TPM_REPORT_DATA_SIZE);
         }
         report_data.resize(TPM_REPORT_DATA_SIZE, 0);
+
+        // Read the deterministic EK before creating and quoting with an AK.
+        // Coconut's vTPM can otherwise keep returning TPM2_RC_RETRY when a new
+        // EK primary is created immediately after the quote contexts close.
+        let engine = base64::engine::general_purpose::STANDARD;
+        let ek_pubkey = engine.encode(dump_ek_pub()?);
+        let quote_algorithms = supported_quote_algorithms()?;
 
         let mut keylime_uuid: Option<String> = None;
         let mut quote = HashMap::new();
@@ -93,14 +122,12 @@ impl Attester for TpmAttester {
                                 ak_private: private,
                                 ak_public: public,
                             };
-                            quote.insert(
-                                "SHA1".to_string(),
-                                get_quote(ak.clone(), &report_data, "SHA1")?,
-                            );
-                            quote.insert(
-                                "SHA256".to_string(),
-                                get_quote(ak.clone(), &report_data, "SHA256")?,
-                            );
+                            for algorithm in &quote_algorithms {
+                                quote.insert(
+                                    (*algorithm).to_string(),
+                                    get_quote(ak.clone(), &report_data, algorithm)?,
+                                );
+                            }
                             ak_pubkey_pem = Some(
                                 get_ak_pub(ak)?
                                     .to_public_key_pem(rust_rsa::pkcs8::LineEnding::LF)?,
@@ -119,20 +146,17 @@ impl Attester for TpmAttester {
 
         if ak_pubkey_pem.is_none() {
             let attestation_key = generate_rsa_ak()?;
-            quote.insert(
-                "SHA1".to_string(),
-                get_quote(attestation_key.clone(), &report_data, "SHA1")?,
-            );
-            quote.insert(
-                "SHA256".to_string(),
-                get_quote(attestation_key.clone(), &report_data, "SHA256")?,
-            );
+            for algorithm in &quote_algorithms {
+                quote.insert(
+                    (*algorithm).to_string(),
+                    get_quote(attestation_key.clone(), &report_data, algorithm)?,
+                );
+            }
             ak_pubkey_pem = Some(
                 get_ak_pub(attestation_key)?.to_public_key_pem(rust_rsa::pkcs8::LineEnding::LF)?,
             );
         }
 
-        let engine = base64::engine::general_purpose::STANDARD;
         let eventlog = match std::fs::read(TPM_EVENTLOG_FILE_PATH) {
             Result::Ok(el) => Some(engine.encode(el)),
             Result::Err(e) => {
@@ -140,10 +164,16 @@ impl Attester for TpmAttester {
                 None
             }
         };
-        let aa_eventlog = read_eventlog().await?;
+        let aa_eventlog = read_aa_eventlog().await?;
+        let ek_cert = if is_svsm_vtpm() {
+            None
+        } else {
+            dump_ek_cert_pem().ok()
+        };
 
         let evidence = TpmEvidence {
-            ek_cert: dump_ek_cert_pem().ok(),
+            ek_pubkey,
+            ek_cert,
             ak_pubkey: ak_pubkey_pem.ok_or_else(|| anyhow!("AK pubkey must be set"))?,
             keylime_agent_uuid: keylime_uuid,
             quote,
@@ -153,6 +183,10 @@ impl Attester for TpmAttester {
 
         serde_json::to_value(evidence)
             .map_err(|e| anyhow!("Serialize TPM evidence failed: {:?}", e))
+    }
+
+    fn supports_runtime_measurement(&self) -> bool {
+        true
     }
 
     async fn extend_runtime_measurement(&self, digest: Vec<u8>, index: u64) -> Result<()> {
@@ -184,6 +218,16 @@ impl Attester for TpmAttester {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn detect_svsm_vtpm_from_modalias() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("modalias"), "platform:tpm-svsm\n").unwrap();
+        assert!(is_svsm_vtpm_device(dir.path()));
+
+        std::fs::write(dir.path().join("modalias"), "platform:tpm-crb\n").unwrap();
+        assert!(!is_svsm_vtpm_device(dir.path()));
+    }
     #[ignore]
     #[tokio::test]
     async fn test_tpm_get_evidence() {

--- a/attestation-agent/attester/src/tpm/utils.rs
+++ b/attestation-agent/attester/src/tpm/utils.rs
@@ -18,7 +18,7 @@ use tss_esapi::abstraction::{
     AsymmetricAlgorithmSelection, DefaultKey,
 };
 use tss_esapi::attributes::SessionAttributesBuilder;
-use tss_esapi::constants::SessionType;
+use tss_esapi::constants::{CapabilityType, SessionType};
 use tss_esapi::handles::{KeyHandle, PcrHandle};
 use tss_esapi::interface_types::algorithm::{
     AsymmetricAlgorithm, HashingAlgorithm, SignatureSchemeAlgorithm,
@@ -26,8 +26,8 @@ use tss_esapi::interface_types::algorithm::{
 use tss_esapi::interface_types::key_bits::RsaKeyBits;
 use tss_esapi::structures::digest_values::DigestValues;
 use tss_esapi::structures::{
-    pcr_selection_list::PcrSelectionListBuilder, pcr_slot::PcrSlot, AttestInfo, PcrSelectionList,
-    Private, Public, Signature, SignatureScheme, SymmetricDefinition,
+    pcr_selection_list::PcrSelectionListBuilder, pcr_slot::PcrSlot, AttestInfo, CapabilityData,
+    PcrSelectionList, Private, Public, Signature, SignatureScheme, SymmetricDefinition,
 };
 use tss_esapi::tcti_ldr::{DeviceConfig, TctiNameConf};
 use tss_esapi::traits::Marshall;
@@ -112,6 +112,46 @@ pub fn create_pcr_selection_list(algorithm: &str) -> Result<PcrSelectionList> {
     }
 }
 
+/// Return the PCR banks that this attester can quote and serialize.
+///
+/// Some TPM 2.0 implementations advertise an empty SHA-1 bank. Asking
+/// `pcr::read_all` to read such a bank can loop forever because the TPM keeps
+/// returning an empty selection. Query the assigned-PCR capability first and
+/// only quote banks with at least one allocated PCR.
+pub fn supported_quote_algorithms() -> Result<Vec<&'static str>> {
+    let mut context = create_ctx_without_session()?;
+    let (capability, _) = context.get_capability(
+        CapabilityType::AssignedPcr,
+        0,
+        PcrSelectionList::MAX_SIZE as u32,
+    )?;
+    let CapabilityData::AssignedPcr(selections) = capability else {
+        bail!("TPM returned unexpected data for assigned PCR capability");
+    };
+
+    let mut algorithms = Vec::new();
+    for selection in selections.get_selections() {
+        if selection.selected().is_empty() {
+            continue;
+        }
+        let algorithm = match selection.hashing_algorithm() {
+            HashingAlgorithm::Sha1 => Some("SHA1"),
+            HashingAlgorithm::Sha256 => Some("SHA256"),
+            _ => None,
+        };
+        if let Some(algorithm) = algorithm {
+            if !algorithms.contains(&algorithm) {
+                algorithms.push(algorithm);
+            }
+        }
+    }
+
+    if algorithms.is_empty() {
+        bail!("TPM has no supported allocated PCR bank (SHA1 or SHA256)");
+    }
+    Ok(algorithms)
+}
+
 pub fn pcr_extend(digest: Vec<u8>, index: u64) -> Result<()> {
     let mut ctx = create_ctx_with_session()?;
 
@@ -150,6 +190,17 @@ pub fn dump_ek_cert_pem() -> Result<String> {
     let ek_cert = String::from_utf8(ek_cert_pem_bytes)?;
 
     Ok(ek_cert)
+}
+
+/// Return the marshalled TPMT_PUBLIC of the RSA endorsement key.
+///
+/// Coconut-SVSM manifest version 0 uses the same representation, allowing a
+/// verifier to bind the TPM evidence to the vTPM attested by the VMPL0 report.
+pub fn dump_ek_pub() -> Result<Vec<u8>> {
+    let mut context = create_ctx_without_session()?;
+    let ek_handle = create_ek_object(&mut context, AsymmetricAlgorithm::Rsa, DefaultKey)?;
+    let (public, _, _) = context.read_public(ek_handle)?;
+    public.marshall().context("Marshal EK TPMT_PUBLIC")
 }
 
 pub fn dump_pcrs(algorithm: &str) -> Result<Vec<String>> {

--- a/attestation-agent/attester/src/tsm_report/mod.rs
+++ b/attestation-agent/attester/src/tsm_report/mod.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use std::cell::Cell;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use strum::EnumString;
@@ -25,10 +26,12 @@ pub enum TsmReportError {
     MissingProvider(TsmReportProvider, TsmReportProvider),
     #[error("Failed to open TSM Report path: unknown provider ({0})")]
     UnknownProvider(#[from] strum::ParseError),
-    #[error("Failed to generate TSM Report: inblob write conflict (generation={0}, expected 1)")]
-    InblobConflict(u32),
     #[error("Failed to generate TSM Report: missing inblob (len=0)")]
     InblobLen,
+    #[error(
+        "Failed to generate TSM Report: concurrent attribute write (generation={0}, expected {1})"
+    )]
+    GenerationConflict(u32, u32),
 }
 
 #[derive(PartialEq, Debug, EnumString)]
@@ -45,6 +48,13 @@ pub enum TsmReportData {
     Cca(Vec<u8>),
     Tdx(Vec<u8>),
     Sev(u8, Vec<u8>),
+    /// Request a VMPL0 report from an SVSM and bind the selected service
+    /// manifest into REPORT_DATA.
+    SevSvsm {
+        inblob: Vec<u8>,
+        service_guid: String,
+        manifest_version: u32,
+    },
 }
 
 /// TsmReportPath instance represents a unique path on ConfigFS
@@ -53,6 +63,7 @@ pub enum TsmReportData {
 /// automatically removed when the instance goes out of scope.
 pub struct TsmReportPath {
     path: PathBuf,
+    expected_generation: Cell<u32>,
 }
 
 impl Drop for TsmReportPath {
@@ -75,12 +86,35 @@ impl TsmReportPath {
         // path (rmdir way) when TsmReportPath instance goes out of scope.
         let path = p.into_path();
 
-        if check_tsm_report_provider(path.as_path(), wanted).is_err() {
+        if let Err(e) = check_tsm_report_provider(path.as_path(), wanted) {
             let _ = std::fs::remove_dir(path.as_path());
+            return Err(e);
         }
 
-        Ok(Self { path })
+        Ok(Self {
+            path,
+            expected_generation: Cell::new(0),
+        })
     }
+
+    fn write_attribute(
+        &self,
+        name: &'static str,
+        value: impl AsRef<[u8]>,
+    ) -> Result<(), TsmReportError> {
+        std::fs::write(self.path.join(name), value).map_err(|e| TsmReportError::Access(name, e))?;
+        self.expected_generation
+            .set(self.expected_generation.get() + 1);
+        Ok(())
+    }
+
+    /// Whether this TSM provider exposes the SVSM service attestation ABI.
+    pub fn supports_svsm_attestation(&self) -> bool {
+        self.path.join("service_provider").exists()
+            && self.path.join("service_guid").exists()
+            && self.path.join("manifestblob").exists()
+    }
+
     pub fn attestation_report(
         &self,
         provider_data: TsmReportData,
@@ -92,8 +126,17 @@ impl TsmReportPath {
             TsmReportData::Tdx(inblob) => inblob,
             TsmReportData::Sev(privlevel, inblob) => {
                 // TODO: untested
-                std::fs::write(report_path.join("privlevel"), vec![privlevel])
-                    .map_err(|e| TsmReportError::Access("privlevel", e))?;
+                self.write_attribute("privlevel", privlevel.to_string())?;
+                inblob
+            }
+            TsmReportData::SevSvsm {
+                inblob,
+                service_guid,
+                manifest_version,
+            } => {
+                self.write_attribute("service_provider", "svsm")?;
+                self.write_attribute("service_guid", service_guid)?;
+                self.write_attribute("service_manifest_version", manifest_version.to_string())?;
                 inblob
             }
         };
@@ -102,13 +145,12 @@ impl TsmReportPath {
             return Err(TsmReportError::InblobLen);
         }
 
-        std::fs::write(report_path.join("inblob"), report_data)
-            .map_err(|e| TsmReportError::Access("inblob", e))?;
+        self.write_attribute("inblob", report_data)?;
 
         let q = std::fs::read(report_path.join("outblob"))
             .map_err(|e| TsmReportError::Access("outblob", e))?;
 
-        check_inblob_write_race(report_path)?;
+        check_inblob_write_race(report_path, self.expected_generation.get())?;
 
         Ok(q)
     }
@@ -118,9 +160,19 @@ impl TsmReportPath {
         let aux = std::fs::read(report_path.join("auxblob"))
             .map_err(|e| TsmReportError::Access("auxblob", e))?;
 
-        check_inblob_write_race(report_path)?;
+        check_inblob_write_race(report_path, self.expected_generation.get())?;
 
         Ok(aux)
+    }
+
+    pub fn manifest_data(&self) -> Result<Vec<u8>, TsmReportError> {
+        let report_path = self.path.as_path();
+        let manifest = std::fs::read(report_path.join("manifestblob"))
+            .map_err(|e| TsmReportError::Access("manifestblob", e))?;
+
+        check_inblob_write_race(report_path, self.expected_generation.get())?;
+
+        Ok(manifest)
     }
 }
 
@@ -129,7 +181,10 @@ impl TsmReportPath {
 /// inblob was written by the TsmReportPath instance. It prevents
 /// the race condition that someone else could use the same temporary
 /// directory to generate a quote.
-fn check_inblob_write_race(report_path: &Path) -> Result<(), TsmReportError> {
+fn check_inblob_write_race(
+    report_path: &Path,
+    expected_generation: u32,
+) -> Result<(), TsmReportError> {
     let g = std::fs::read_to_string(report_path.join("generation"))
         .map_err(|e| TsmReportError::Access("generation", e))?;
 
@@ -139,8 +194,11 @@ fn check_inblob_write_race(report_path: &Path) -> Result<(), TsmReportError> {
         .parse::<u32>()
         .map_err(TsmReportError::Parse)?;
 
-    if generation > 1 {
-        return Err(TsmReportError::InblobConflict(generation));
+    if generation != expected_generation {
+        return Err(TsmReportError::GenerationConflict(
+            generation,
+            expected_generation,
+        ));
     }
 
     Ok(())
@@ -191,7 +249,7 @@ mod tests {
             ),
             "generation" => assert_eq!(
                 expect_error,
-                check_inblob_write_race(tsm_dir.path()).is_err(),
+                check_inblob_write_race(tsm_dir.path(), 1).is_err(),
             ),
             _ => unimplemented!(),
         }

--- a/attestation-agent/attester/src/types.rs
+++ b/attestation-agent/attester/src/types.rs
@@ -9,6 +9,9 @@ use std::collections::HashMap;
 /// TPM Evidence
 #[derive(Serialize, Deserialize)]
 pub struct TpmEvidence {
+    // Base64-encoded TPMT_PUBLIC for the endorsement key. For an SVSM vTPM
+    // this is compared with the manifest bound into the VMPL0 SNP report.
+    pub ek_pubkey: String,
     // PEM format of EK certificate
     pub ek_cert: Option<String>,
     // PEM format of AK public key

--- a/attestation-agent/attester/src/utils.rs
+++ b/attestation-agent/attester/src/utils.rs
@@ -166,6 +166,25 @@ pub async fn read_eventlog() -> Result<Option<String>> {
     Ok(Some(STANDARD.encode(eventlog)))
 }
 
+/// Read only the Attestation Agent runtime event log.
+///
+/// TPM evidence already carries the firmware TPM event log separately.  Do
+/// not prepend a platform CCEL here, otherwise a verifier that replays both
+/// fields could extend the firmware events twice.
+pub async fn read_aa_eventlog() -> Result<Option<String>> {
+    let aael_path = env::var("AAEL_PATH").unwrap_or(DEFAULT_AAEL_PATH.to_string());
+    if !Path::new(&aael_path).exists() {
+        return Ok(None);
+    }
+
+    let mut eventlog = EL_HEADER.to_vec();
+    let mut file = File::open(aael_path).await?;
+    file.read_to_end(&mut eventlog).await?;
+    eventlog.extend_from_slice(&EL_END_FLAG);
+
+    Ok(Some(STANDARD.encode(eventlog)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- collect a VMPL0 SNP report and Coconut vTPM service manifest through the Linux TSM SVSM ABI
- detect only the in-guest `tpm-svsm` device as additional TPM evidence for an SNP guest
- route AA runtime measurements to the additional TPM while SNP remains the primary attester
- include the vTPM EK public area, quote only allocated PCR banks, and avoid probing a manufacturer EK certificate on an SVSM vTPM
- keep firmware TPM eventlog and AA runtime eventlog separate so verifiers replay boot events only once
- keep Keylime optional; an AK loaded from Keylime is used only when `KEYLIME_AGENT_UUID` is configured
- preserve plain SEV-SNP remote attestation when SVSM/TPM is absent: an enabled runtime eventlog now warns and degrades instead of preventing AA startup

Companion verifier change: https://github.com/openanolis/trustee/pull/212

## Validation

Local:

- `cargo test -p attester --no-default-features --features snp-attester,tpm-attester,bin`: 12 passed, 1 ignored
- Attestation Agent production feature tests: 22 passed, 3 ignored; client test: 1 passed
- release build with `rust-crypto,kbs,snp-attester,tpm-attester,eventlog,bin,ttrpc`: passed

Real AMD EPYC Turin SEV-SNP E2E with Coconut SVSM and Fedora 44 (`6.19.10-300.fc44.x86_64`):

- guest ran at VMPL2 and exposed `/dev/sev-guest`, `/dev/tpm0`, `/dev/tpmrm0`, `sev_guest`, `tsm_report`, and `tpm_svsm`
- AA extended a runtime event into PCR10 and persisted a 99-byte AAEL
- PCR10 changed from zero to `02f713ae04900eeb2a9b569538fe8cf5536d25934979cf01316e81676dac0d35`
- the composite SNP + TPM evidence was accepted through Trustee KBS
- `api-server-rest` returned the real primary/additional evidence; direct RESTful AS and gRPC AS both accepted it with a fresh signed AS challenge, and both issued tokens containing the AAEL event and updated PCR10
- the companion AS rejected manifest/EK mismatch, TPM evidence splicing, and mismatched base runtime data

Real plain SEV-SNP compatibility E2E on the same Turin host, without SVSM or TPM:

- guest ran at VMPL0 with `/dev/sev-guest`; `/dev/tpm0` and `/dev/tpmrm0` were absent
- AA was intentionally started with `enable_eventlog=true`; it logged the no-backend warning, stayed available, and reported `snp`
- emitted SNP report was version 5 at VMPL0 with no `svsm_manifest` or additional evidence
- Trustee PR #212 head issued a 1702-byte EAR token containing only SNP claims
- runtime measurement extension returned an explicit error and did not create a false AAEL

The stock Alibaba Cloud Linux 4.0.4 guest was evaluated first. Its native kernel lacks `CONFIG_TCG_SVSM`, and with the recent OVMF required by Coconut its boot path page-faulted in `\EFI\BOOT\fbx64.efi` before entering Linux. Fedora 44 was therefore used for the complete SVSM vTPM and pure-SNP compatibility validation.
