### PR TITLE
fix(cdh): serialize environment-dependent config tests

### DIFF
--- a/confidential-data-hub/hub/src/config.rs
+++ b/confidential-data-hub/hub/src/config.rs
@@ -309,6 +309,7 @@ some_undefined_field = "unknown value"
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_config_path() {
         // --config takes precedence,
         // then env.CDH_CONFIG_PATH
@@ -343,6 +344,7 @@ some_undefined_field = "unknown value"
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_config_auth_override_by_env() {
         let config = r#"
 [kbc]


### PR DESCRIPTION
## Summary

- serialize the two CDH config tests that share process-wide environment variables
- prevent `test_config_path` from observing the temporary registry credential override set by `test_config_auth_override_by_env`
- reuse the existing `serial_test` dev dependency without changing production code or dependencies

## Root cause

Rust unit tests run in parallel by default. `test_config_auth_override_by_env` temporarily sets `CDH_DEFAULT_IMAGE_AUTHENTICATED_REGISTRY_CREDENTIALS`, while `test_config_path` calls `CdhConfig::new()` and assumes that variable is absent. When their execution overlaps, `test_config_path` sees `file:///test` and fails nondeterministically.

## Validation

- reproduced the failure before the fix on iteration 18 with `--test-threads=2`
- ran the two affected tests 500 times with two test threads after the fix: all passed
- `cargo +1.76.0 fmt --all -- --check`
- `cargo +1.76.0 test -p confidential-data-hub`
- `cargo +1.76.0 clippy -p confidential-data-hub -- -D warnings`
