### PR TITLE
feat: align Trustee resource URIs and AA runtime measurements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,6 +1198,7 @@ dependencies = [
  "protos",
  "rand 0.9.2",
  "reqwest 0.12.9",
+ "resource_uri",
  "rstest",
  "serde",
  "serde_json",

--- a/api-server-rest/src/aa.rs
+++ b/api-server-rest/src/aa.rs
@@ -11,7 +11,7 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use hyper::{body, Body, Method, Request, Response};
 use protos::ttrpc::aa::attestation_agent::{
     ExtendRuntimeMeasurementRequest, GetAdditionalEvidenceRequest, GetAdditionalTeesRequest,
-    GetEvidenceRequest, GetTeeTypeRequest, GetTokenRequest,
+    GetEvidenceRequest, GetTeeTypeRequest, GetTokenRequest, RuntimeMeasurementResult,
 };
 use protos::ttrpc::aa::attestation_agent_ttrpc::AttestationAgentServiceClient;
 use serde::Deserialize;
@@ -142,10 +142,15 @@ impl ApiHandler for AAClient {
                     )
                     .await
                 {
-                    std::result::Result::Ok(_) => {
+                    std::result::Result::Ok(RuntimeMeasurementResult::OK) => {
                         return Ok(Response::builder()
                             .status(hyper::StatusCode::OK)
                             .body(Body::empty())?)
+                    }
+                    std::result::Result::Ok(result) => {
+                        return Ok(Response::builder()
+                            .status(runtime_measurement_status(result))
+                            .body(Body::from(format!("{result:?}")))?)
                     }
                     Err(e) => return self.internal_error(e.to_string()),
                 }
@@ -238,7 +243,7 @@ impl AAClient {
         domain: &str,
         operation: &str,
         content: &str,
-    ) -> Result<()> {
+    ) -> Result<RuntimeMeasurementResult> {
         let req = ExtendRuntimeMeasurementRequest {
             Domain: domain.to_string(),
             Operation: operation.to_string(),
@@ -247,11 +252,23 @@ impl AAClient {
             ..Default::default()
         };
 
-        self.client
+        let response = self
+            .client
             .extend_runtime_measurement(ttrpc::context::with_timeout(TTRPC_TIMEOUT), &req)
             .await
             .context("ttrpc extend_runtime_measurement failed")?;
-        Ok(())
+        response
+            .Result
+            .enum_value()
+            .map_err(|value| anyhow!("unknown runtime measurement result: {value}"))
+    }
+}
+
+fn runtime_measurement_status(result: RuntimeMeasurementResult) -> hyper::StatusCode {
+    match result {
+        RuntimeMeasurementResult::OK => hyper::StatusCode::OK,
+        RuntimeMeasurementResult::NOT_SUPPORTED => hyper::StatusCode::NOT_IMPLEMENTED,
+        RuntimeMeasurementResult::NOT_ENABLED => hyper::StatusCode::CONFLICT,
     }
 }
 
@@ -296,6 +313,22 @@ fn parse_evidence_runtime_data(runtime_data: &str, encoding: Option<&str>) -> Re
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn runtime_measurement_results_have_distinct_http_statuses() {
+        assert_eq!(
+            runtime_measurement_status(RuntimeMeasurementResult::OK),
+            hyper::StatusCode::OK
+        );
+        assert_eq!(
+            runtime_measurement_status(RuntimeMeasurementResult::NOT_SUPPORTED),
+            hyper::StatusCode::NOT_IMPLEMENTED
+        );
+        assert_eq!(
+            runtime_measurement_status(RuntimeMeasurementResult::NOT_ENABLED),
+            hyper::StatusCode::CONFLICT
+        );
+    }
 
     fn local_addr() -> SocketAddr {
         SocketAddr::from(([127, 0, 0, 1], 8006))

--- a/attestation-agent/attestation-agent/src/bin/grpc-aa/server.rs
+++ b/attestation-agent/attestation-agent/src/bin/grpc-aa/server.rs
@@ -4,14 +4,14 @@
 //
 
 use anyhow::*;
-use attestation_agent::{AttestationAPIs, AttestationAgent};
+use attestation_agent::{AttestationAPIs, AttestationAgent, RuntimeMeasurement};
 use log::{debug, error};
 use protos::grpc::aa::attestation_agent::{
     attestation_agent_service_server::{AttestationAgentService, AttestationAgentServiceServer},
     BindInitDataRequest, BindInitDataResponse, ExtendRuntimeMeasurementRequest,
     ExtendRuntimeMeasurementResponse, GetAdditionalEvidenceRequest, GetAdditionalTeesRequest,
     GetAdditionalTeesResponse, GetEvidenceRequest, GetEvidenceResponse, GetTeeTypeRequest,
-    GetTeeTypeResponse, GetTokenRequest, GetTokenResponse,
+    GetTeeTypeResponse, GetTokenRequest, GetTokenResponse, RuntimeMeasurementResult,
 };
 use std::net::SocketAddr;
 use tonic::{transport::Server, Request, Response, Status};
@@ -106,7 +106,8 @@ impl AttestationAgentService for AA {
 
         debug!("AA (grpc): extend runtime measurement ...");
 
-        self.inner
+        let result = self
+            .inner
             .extend_runtime_measurement(
                 &request.domain,
                 &request.operation,
@@ -123,7 +124,13 @@ impl AttestationAgentService for AA {
 
         debug!("AA (grpc): extend runtime measurement succeeded.");
 
-        let reply = ExtendRuntimeMeasurementResponse {};
+        let reply = ExtendRuntimeMeasurementResponse {
+            result: match result {
+                RuntimeMeasurement::Ok => RuntimeMeasurementResult::Ok.into(),
+                RuntimeMeasurement::NotSupported => RuntimeMeasurementResult::NotSupported.into(),
+                RuntimeMeasurement::NotEnabled => RuntimeMeasurementResult::NotEnabled.into(),
+            },
+        };
 
         Result::Ok(Response::new(reply))
     }

--- a/attestation-agent/attestation-agent/src/bin/ttrpc-aa-client.rs
+++ b/attestation-agent/attestation-agent/src/bin/ttrpc-aa-client.rs
@@ -10,6 +10,7 @@ use const_format::concatcp;
 use protos::ttrpc::aa::{
     attestation_agent::{
         ExtendRuntimeMeasurementRequest, GetEvidenceRequest, GetTeeTypeRequest, GetTokenRequest,
+        RuntimeMeasurementResult,
     },
     attestation_agent_ttrpc::AttestationAgentServiceClient,
 };
@@ -196,11 +197,23 @@ pub async fn main() {
                 ..Default::default()
             };
 
-            client
+            let response = client
                 .extend_runtime_measurement(context::with_timeout(timeout), &req)
                 .await
                 .expect("request to AA");
-            println!("Extended.");
+            match response
+                .Result
+                .enum_value()
+                .expect("invalid runtime measurement result")
+            {
+                RuntimeMeasurementResult::OK => println!("Extended."),
+                RuntimeMeasurementResult::NOT_SUPPORTED => {
+                    println!("Current platform does not support runtime measurement.")
+                }
+                RuntimeMeasurementResult::NOT_ENABLED => println!(
+                    "Runtime measurement is not enabled in Attestation Agent configuration."
+                ),
+            }
         }
     }
 }

--- a/attestation-agent/attestation-agent/src/bin/ttrpc_dep/server.rs
+++ b/attestation-agent/attestation-agent/src/bin/ttrpc_dep/server.rs
@@ -5,7 +5,7 @@
 
 use ::ttrpc::proto::Code;
 use async_trait::async_trait;
-use attestation_agent::{AttestationAPIs, AttestationAgent};
+use attestation_agent::{AttestationAPIs, AttestationAgent, RuntimeMeasurement};
 use log::{debug, error};
 
 use protos::ttrpc::aa::{
@@ -13,7 +13,7 @@ use protos::ttrpc::aa::{
         ExtendRuntimeMeasurementRequest, ExtendRuntimeMeasurementResponse,
         GetAdditionalEvidenceRequest, GetAdditionalTeesRequest, GetAdditionalTeesResponse,
         GetEvidenceRequest, GetEvidenceResponse, GetTeeTypeRequest, GetTeeTypeResponse,
-        GetTokenRequest, GetTokenResponse,
+        GetTokenRequest, GetTokenResponse, RuntimeMeasurementResult,
     },
     attestation_agent_ttrpc::AttestationAgentService,
 };
@@ -116,7 +116,8 @@ impl AttestationAgentService for AA {
     ) -> ::ttrpc::Result<ExtendRuntimeMeasurementResponse> {
         debug!("AA (ttrpc): extend runtime measurement ...");
 
-        self.inner
+        let result = self
+            .inner
             .extend_runtime_measurement(
                 &req.Domain,
                 &req.Operation,
@@ -135,7 +136,12 @@ impl AttestationAgentService for AA {
             })?;
 
         debug!("AA (ttrpc): extend runtime measurement succeeded.");
-        let reply = ExtendRuntimeMeasurementResponse::new();
+        let mut reply = ExtendRuntimeMeasurementResponse::new();
+        reply.Result = match result {
+            RuntimeMeasurement::Ok => RuntimeMeasurementResult::OK.into(),
+            RuntimeMeasurement::NotSupported => RuntimeMeasurementResult::NOT_SUPPORTED.into(),
+            RuntimeMeasurement::NotEnabled => RuntimeMeasurementResult::NOT_ENABLED.into(),
+        };
         ::ttrpc::Result::Ok(reply)
     }
 

--- a/attestation-agent/attestation-agent/src/lib.rs
+++ b/attestation-agent/attestation-agent/src/lib.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use attester::{detect_attestable_devices, detect_tee_type, BoxedAttester};
 use kbs_types::Tee;
@@ -25,6 +25,18 @@ use log::{debug, info, warn};
 use token::*;
 
 use crate::{config::Config, eventlog::Event};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RuntimeMeasurement {
+    /// The runtime measurement was extended successfully.
+    Ok,
+
+    /// No detected attester can extend a runtime measurement register.
+    NotSupported,
+
+    /// Runtime measurement/eventlog support is disabled in AA configuration.
+    NotEnabled,
+}
 
 /// Attestation Agent (AA for short) is a rust library crate for attestation procedure
 /// in confidential containers. It provides kinds of service APIs related to attestation,
@@ -75,7 +87,7 @@ pub trait AttestationAPIs {
         operation: &str,
         content: &str,
         register_index: Option<u64>,
-    ) -> Result<()>;
+    ) -> Result<RuntimeMeasurement>;
 
     /// Bind initdata
     async fn bind_init_data(&self, init_data: &[u8]) -> Result<InitDataResult>;
@@ -272,9 +284,13 @@ impl AttestationAPIs for AttestationAgent {
         operation: &str,
         content: &str,
         register_index: Option<u64>,
-    ) -> Result<()> {
+    ) -> Result<RuntimeMeasurement> {
         let Some(ref eventlog) = self.eventlog else {
-            bail!("Extend eventlog not enabled when launching!");
+            return if self.config.read().await.eventlog_config.enable_eventlog {
+                Ok(RuntimeMeasurement::NotSupported)
+            } else {
+                Ok(RuntimeMeasurement::NotEnabled)
+            };
         };
 
         let (pcr, log_entry) = {
@@ -293,7 +309,7 @@ impl AttestationAPIs for AttestationAgent {
 
         eventlog.lock().await.extend_entry(log_entry, pcr).await?;
 
-        Ok(())
+        Ok(RuntimeMeasurement::Ok)
     }
 
     /// Perform the initdata binding. If current platform does not support initdata
@@ -317,6 +333,16 @@ impl AttestationAPIs for AttestationAgent {
 mod tests {
     use super::*;
 
+    #[derive(Debug)]
+    struct UnsupportedMeasurementAttester;
+
+    #[async_trait::async_trait]
+    impl attester::Attester for UnsupportedMeasurementAttester {
+        async fn get_evidence(&self, _report_data: Vec<u8>) -> Result<attester::TeeEvidence> {
+            Ok(serde_json::json!({"tee": "unsupported-measurement-test"}))
+        }
+    }
+
     #[tokio::test]
     async fn test_attestation_agent() {
         let res = AttestationAgent::new(None);
@@ -325,15 +351,26 @@ mod tests {
         assert!(aa.get_token("kbs", None).await.is_err());
         assert!(aa.get_evidence(&[]).await.is_ok());
         assert!(aa.bind_init_data(&[]).await.is_ok());
-        assert!(aa
-            .extend_runtime_measurement("domain", "event", "operation", None)
-            .await
-            .is_err());
+        assert_eq!(
+            aa.extend_runtime_measurement("domain", "event", "operation", None)
+                .await
+                .unwrap(),
+            RuntimeMeasurement::NotEnabled
+        );
     }
 
     #[tokio::test]
     async fn test_attestation_agent_with_aa_instance_config() {
         let mut aa = AttestationAgent::new(Some("tests/aa_instance_info_test.toml")).unwrap();
+        // This test covers instance-info initialization, not the eventlog. Keep
+        // it independent of the process user's permission to write under /run.
+        {
+            let mut config = aa.config.write().await;
+            config.eventlog_config.enable_eventlog = false;
+            // Force the documented failure path without depending on live cloud
+            // metadata or writing an instance-info file below /run.
+            config.aa_instance.instance_type = Some("unsupported-test-instance".to_string());
+        }
         // Test that initialization doesn't fail even if AA instance info retrieval fails
         // (which is expected in test environment without actual cloud metadata)
         aa.init().await.expect("init should not fail");
@@ -346,6 +383,8 @@ mod tests {
     #[tokio::test]
     async fn test_eventlog_without_measurement_backend_degrades_gracefully() {
         let mut aa = AttestationAgent::new(None).unwrap();
+        aa.primary_attester = Arc::new(Box::new(UnsupportedMeasurementAttester));
+        aa.additional_attesters.clear();
         aa.config.write().await.eventlog_config.enable_eventlog = true;
 
         aa.init()
@@ -354,9 +393,11 @@ mod tests {
 
         assert!(aa.eventlog.is_none());
         assert!(aa.get_evidence(&[0; 64]).await.is_ok());
-        assert!(aa
-            .extend_runtime_measurement("domain", "operation", "content", None)
-            .await
-            .is_err());
+        assert_eq!(
+            aa.extend_runtime_measurement("domain", "operation", "content", None)
+                .await
+                .unwrap(),
+            RuntimeMeasurement::NotSupported
+        );
     }
 }

--- a/attestation-agent/attestation-agent/src/token/kbs.rs
+++ b/attestation-agent/attestation-agent/src/token/kbs.rs
@@ -65,11 +65,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_kbs_token_getter() {
-        let config = KbsConfig {
-            url: "http://127.0.0.1:8080".to_string(),
+        // Construct directly so a process-global TRUSTEE_URL or a service on
+        // the conventional test port cannot make this negative test flaky.
+        let getter = KbsTokenGetter {
+            kbs_host_url: "http://127.0.0.1:0".to_string(),
             cert: None,
         };
-        let getter = KbsTokenGetter::new(&config);
         let token = getter.get_token(None).await;
         assert!(token.is_err());
     }

--- a/attestation-agent/attester/src/az_snp_vtpm/mod.rs
+++ b/attestation-agent/attester/src/az_snp_vtpm/mod.rs
@@ -6,6 +6,7 @@
 use super::{Attester, InitDataResult, TeeEvidence};
 use anyhow::{bail, Context, Result};
 use az_snp_vtpm::{imds, is_snp_cvm, vtpm};
+use kbs_types::HashAlgorithm;
 use log::{debug, info};
 use serde::{Deserialize, Serialize};
 
@@ -46,6 +47,10 @@ impl Attester for AzSnpVtpmAttester {
         Ok(serde_json::to_value(evidence)?)
     }
 
+    fn supports_runtime_measurement(&self) -> bool {
+        true
+    }
+
     async fn bind_init_data(&self, init_data_digest: &[u8]) -> anyhow::Result<InitDataResult> {
         utils::extend_pcr(init_data_digest, utils::INIT_DATA_PCR)?;
         Ok(InitDataResult::Ok)
@@ -58,6 +63,18 @@ impl Attester for AzSnpVtpmAttester {
     ) -> Result<()> {
         utils::extend_pcr(&event_digest, register_index as u8)?;
         Ok(())
+    }
+
+    async fn get_runtime_measurement(&self, pcr_index: u64) -> Result<Vec<u8>> {
+        utils::read_pcr(pcr_index)
+    }
+
+    fn pcr_to_ccmr(&self, pcr_index: u64) -> u64 {
+        pcr_index
+    }
+
+    fn ccel_hash_algorithm(&self) -> HashAlgorithm {
+        HashAlgorithm::Sha256
     }
 }
 
@@ -75,5 +92,24 @@ pub(crate) mod utils {
         vtpm::extend_pcr(pcr, &sha256_digest)?;
 
         Ok(())
+    }
+
+    /// Read a SHA-256 PCR through the quote interface exposed by the current
+    /// `az-cvm-vtpm` dependency. The quote contains all 24 PCR values in index
+    /// order, so this also works on releases that do not expose a direct PCR
+    /// read API.
+    pub fn read_pcr(pcr_index: u64) -> Result<Vec<u8>> {
+        let index = usize::try_from(pcr_index).context("PCR index does not fit usize")?;
+        if index > 23 {
+            bail!("Invalid PCR index: {pcr_index}");
+        }
+
+        let quote = vtpm::get_quote(&[]).context("quote vTPM while reading PCR")?;
+        let digest = quote
+            .pcrs_sha256()
+            .nth(index)
+            .map(|digest| digest.to_vec())
+            .context("vTPM quote did not contain the requested PCR")?;
+        Ok(digest)
     }
 }

--- a/attestation-agent/attester/src/az_tdx_vtpm/mod.rs
+++ b/attestation-agent/attester/src/az_tdx_vtpm/mod.rs
@@ -8,6 +8,7 @@ use crate::az_snp_vtpm::utils;
 use anyhow::*;
 use az_tdx_vtpm::vtpm::Quote as TpmQuote;
 use az_tdx_vtpm::{hcl, imds, is_tdx_cvm, vtpm};
+use kbs_types::HashAlgorithm;
 use log::debug;
 use serde::{Deserialize, Serialize};
 use std::result::Result::Ok;
@@ -50,6 +51,10 @@ impl Attester for AzTdxVtpmAttester {
         Ok(serde_json::to_value(evidence)?)
     }
 
+    fn supports_runtime_measurement(&self) -> bool {
+        true
+    }
+
     async fn bind_init_data(&self, init_data_digest: &[u8]) -> anyhow::Result<InitDataResult> {
         utils::extend_pcr(init_data_digest, utils::INIT_DATA_PCR)?;
         Ok(InitDataResult::Ok)
@@ -62,5 +67,17 @@ impl Attester for AzTdxVtpmAttester {
     ) -> Result<()> {
         utils::extend_pcr(&event_digest, register_index as u8)?;
         Ok(())
+    }
+
+    async fn get_runtime_measurement(&self, pcr_index: u64) -> Result<Vec<u8>> {
+        utils::read_pcr(pcr_index)
+    }
+
+    fn pcr_to_ccmr(&self, pcr_index: u64) -> u64 {
+        pcr_index
+    }
+
+    fn ccel_hash_algorithm(&self) -> HashAlgorithm {
+        HashAlgorithm::Sha256
     }
 }

--- a/attestation-agent/attester/src/csv/mod.rs
+++ b/attestation-agent/attester/src/csv/mod.rs
@@ -131,6 +131,10 @@ impl Attester for CsvAttester {
         serde_json::to_value(&evidence).context("Serialize CSV evidence failed")
     }
 
+    fn supports_runtime_measurement(&self) -> bool {
+        true
+    }
+
     /// Extend TEE specific dynamic measurement register
     /// to enable dynamic measurement capabilities for input data at runtime.
     async fn extend_runtime_measurement(

--- a/attestation-agent/attester/src/hygon_tpm/mod.rs
+++ b/attestation-agent/attester/src/hygon_tpm/mod.rs
@@ -461,6 +461,10 @@ impl Attester for HygonTpmAttester {
             .map_err(|e| anyhow!("Serialize Hygon TPM evidence failed: {:?}", e))
     }
 
+    fn supports_runtime_measurement(&self) -> bool {
+        true
+    }
+
     async fn extend_runtime_measurement(&self, digest: Vec<u8>, index: u64) -> Result<()> {
         pcr_extend(digest, index)
     }

--- a/attestation-agent/attester/src/lib.rs
+++ b/attestation-agent/attester/src/lib.rs
@@ -259,6 +259,21 @@ mod tests {
     use super::*;
 
     #[test]
+    fn attesters_with_complete_measurement_backends_report_support() {
+        #[cfg(feature = "az-snp-vtpm-attester")]
+        assert!(az_snp_vtpm::AzSnpVtpmAttester.supports_runtime_measurement());
+
+        #[cfg(feature = "az-tdx-vtpm-attester")]
+        assert!(az_tdx_vtpm::AzTdxVtpmAttester.supports_runtime_measurement());
+
+        #[cfg(feature = "csv-attester")]
+        assert!(csv::CsvAttester::default().supports_runtime_measurement());
+
+        #[cfg(feature = "tpm-attester")]
+        assert!(hygon_tpm::HygonTpmAttester::default().supports_runtime_measurement());
+    }
+
+    #[test]
     fn test_detect_tee_type() {
         let tee = detect_tee_type();
         assert_eq!(tee, Tee::Sample);

--- a/attestation-agent/attester/src/sample/mod.rs
+++ b/attestation-agent/attester/src/sample/mod.rs
@@ -44,6 +44,15 @@ impl Default for SampleAttester {
     }
 }
 
+#[cfg(test)]
+impl SampleAttester {
+    fn new_with_measure_register_path(path: &str) -> Self {
+        Self {
+            measure_register: Arc::new(Mutex::new(MeasureRegister::new(path))),
+        }
+    }
+}
+
 #[async_trait::async_trait]
 impl Attester for SampleAttester {
     async fn get_evidence(&self, report_data: Vec<u8>) -> Result<TeeEvidence> {
@@ -66,6 +75,10 @@ impl Attester for SampleAttester {
         };
 
         serde_json::to_value(evidence).map_err(|e| anyhow!("Serialize sample evidence failed: {e}"))
+    }
+
+    fn supports_runtime_measurement(&self) -> bool {
+        true
     }
 
     async fn extend_runtime_measurement(
@@ -118,9 +131,22 @@ mod tests {
 
     #[tokio::test]
     async fn test_sample_attester() {
-        let attester = SampleAttester::default();
+        let tempdir = tempfile::tempdir().unwrap();
+        let register_path = tempdir.path().join("sample_measure_register");
+        let attester = SampleAttester::new_with_measure_register_path(
+            register_path.to_str().expect("temporary path is UTF-8"),
+        );
         let report_data = vec![1, 2, 3, 4, 5];
         let evidence = attester.get_evidence(report_data).await.unwrap();
-        println!("{}", evidence);
+        assert!(evidence.is_object());
+        assert!(attester.supports_runtime_measurement());
+
+        let initial = attester.get_runtime_measurement(0).await.unwrap();
+        attester
+            .extend_runtime_measurement(vec![1; MEASURE_DIGEST_LEN], 0)
+            .await
+            .unwrap();
+        let extended = attester.get_runtime_measurement(0).await.unwrap();
+        assert_ne!(initial, extended);
     }
 }

--- a/attestation-agent/attester/src/system/mod.rs
+++ b/attestation-agent/attester/src/system/mod.rs
@@ -49,6 +49,13 @@ impl SystemAttester {
             runtime_register: Arc::new(Mutex::new(MeasureRegister::new(MEASURE_REGISTER_PATH))),
         })
     }
+
+    #[cfg(test)]
+    fn new_with_measure_register_path(path: &str) -> Self {
+        Self {
+            runtime_register: Arc::new(Mutex::new(MeasureRegister::new(path))),
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -82,6 +89,10 @@ impl Attester for SystemAttester {
             report_data: base64::engine::general_purpose::STANDARD.encode(report_data),
         };
         serde_json::to_value(evidence).context("Serialize system evidence failed")
+    }
+
+    fn supports_runtime_measurement(&self) -> bool {
+        true
     }
 
     async fn extend_runtime_measurement(
@@ -130,12 +141,26 @@ impl Attester for SystemAttester {
 #[cfg(test)]
 mod tests {
     use crate::{system::SystemAttester, Attester};
+    use kbs_types::HashAlgorithm;
 
     #[tokio::test]
     async fn test_system_get_evidence() {
-        let attester = SystemAttester::new().unwrap(); // Update for sync
+        let tempdir = tempfile::tempdir().unwrap();
+        let register_path = tempdir.path().join("system_measure_register");
+        let attester = SystemAttester::new_with_measure_register_path(
+            register_path.to_str().expect("temporary path is UTF-8"),
+        );
         let report_data: Vec<u8> = vec![0; 48];
-        let evidence = attester.get_evidence(report_data).await;
-        assert!(evidence.is_ok());
+        let evidence = attester.get_evidence(report_data).await.unwrap();
+        assert!(evidence.is_object());
+        assert!(attester.supports_runtime_measurement());
+
+        let initial = attester.get_runtime_measurement(0).await.unwrap();
+        attester
+            .extend_runtime_measurement(vec![1; HashAlgorithm::Sha384.digest_len()], 0)
+            .await
+            .unwrap();
+        let extended = attester.get_runtime_measurement(0).await.unwrap();
+        assert_ne!(initial, extended);
     }
 }

--- a/attestation-agent/attester/src/tdx/mod.rs
+++ b/attestation-agent/attester/src/tdx/mod.rs
@@ -203,9 +203,9 @@ impl Attester for TdxAttester {
         serde_json::to_value(evidence).context("Serialize TDX evidence failed")
     }
 
-    // fn supports_runtime_measurement(&self) -> bool {
-    //     true
-    // }
+    fn supports_runtime_measurement(&self) -> bool {
+        runtime_measurement_extend_available()
+    }
 
     async fn extend_runtime_measurement(
         &self,

--- a/attestation-agent/coco_keyprovider/Cargo.toml
+++ b/attestation-agent/coco_keyprovider/Cargo.toml
@@ -21,6 +21,7 @@ protos = { path = "../../protos", default-features = false, features = [
 ] }
 rand.workspace = true
 reqwest.workspace = true
+resource_uri.path = "../deps/resource_uri"
 serde.workspace = true
 serde_json.workspace = true
 strum.workspace = true

--- a/attestation-agent/coco_keyprovider/src/enc_mods/mod.rs
+++ b/attestation-agent/coco_keyprovider/src/enc_mods/mod.rs
@@ -5,12 +5,13 @@
 
 use std::collections::HashMap;
 
-use anyhow::*;
+use anyhow::{anyhow, bail, Context, Result};
 use base64::Engine;
 use jwt_simple::prelude::Ed25519KeyPair;
 use log::{debug, info};
 use rand::TryRngCore;
 use reqwest::Url;
+use resource_uri::ResourceUri;
 use serde::{Deserialize, Serialize};
 use tokio::fs;
 
@@ -150,24 +151,40 @@ async fn generate_key_parameters(input_params: &InputParams) -> Result<(Vec<u8>,
 
 /// Normalize the given keyid into (kbs addr, key path), s.t.
 /// converting `kbs://...` or `../..` to `(<kbs-addr>, <repository>/<type>/<tag>)`.
-fn normalize_path(keyid: &str) -> Result<(String, String)> {
-    debug!("normalize key id {keyid}");
-    let path = keyid.strip_prefix(KBS_RESOURCE_URL_PREFIX).unwrap_or(keyid);
-    let values: Vec<&str> = path.split('/').collect();
+fn normalize_path(key_id: &str) -> Result<(String, String)> {
+    debug!("normalize key id {key_id}");
+
+    if let Ok(resource_uri) = ResourceUri::try_from(key_id) {
+        return Ok((
+            resource_uri.kbs_address.clone(),
+            resource_uri.resource_path(),
+        ));
+    }
+
+    let values: Vec<&str> = key_id.split('/').collect();
     if values.len() == 4 {
-        Ok((
+        return Ok((
             values[0].to_string(),
             format!("{}/{}/{}", values[1], values[2], values[3]),
-        ))
-    } else {
-        bail!(
-            "Resource path {keyid} must follow one of the following formats:
+        ));
+    }
+
+    bail!(
+        "Resource path {key_id} must follow one of the following formats:
                 'kbs:///<repository>/<type>/<tag>'
                 'kbs://<kbs-addr>/<repository>/<type>/<tag>'
+                'kbs+<plugin>:///<path>'
+                'kbs+<plugin>://<kbs-addr>/<path>'
                 '<kbs-addr>/<repository>/<type>/<tag>'
                 '/<repository>/<type>/<tag>'
             "
-        )
+    )
+}
+
+fn normalized_annotation_kid(key_id: &str, kbs_address: &str, key_path: &str) -> String {
+    match ResourceUri::try_from(key_id) {
+        Ok(resource_uri) => resource_uri.whole_uri(),
+        Err(_) => format!("{KBS_RESOURCE_URL_PREFIX}{kbs_address}/{key_path}"),
     }
 }
 
@@ -196,6 +213,7 @@ pub async fn enc_optsdata_gen_anno(
         .context("generating key params")?;
 
     let (kbs_addr, k_path) = normalize_path(&kid)?;
+    let annotation_kid = normalized_annotation_kid(&kid, &kbs_addr, &k_path);
 
     let algorithm = input_params.algorithm;
     let encrypt_optsdata = crypto::encrypt(optsdata, &key, &iv, &algorithm)
@@ -213,7 +231,7 @@ pub async fn enc_optsdata_gen_anno(
 
     let engine = base64::engine::general_purpose::STANDARD;
     let annotation = AnnotationPacket {
-        kid: format!("{KBS_RESOURCE_URL_PREFIX}{kbs_addr}/{k_path}"),
+        kid: annotation_kid,
         wrapped_data: engine.encode(encrypt_optsdata),
         iv: engine.encode(iv),
         wrap_type: algorithm.to_string(),
@@ -229,11 +247,39 @@ mod tests {
     #[rstest]
     #[case("kbs://a/b/c/d", ("a", "b/c/d"))]
     #[case("kbs:///b/c/d", ("", "b/c/d"))]
+    #[case("kbs+pkcs11://a/slot/key/label", ("a", "slot/key/label"))]
+    #[case("kbs+pkcs11:///slot/key/label/version", ("", "slot/key/label/version"))]
     #[case("a/b/c/d", ("a", "b/c/d"))]
     #[case("/b/c/d", ("", "b/c/d"))]
     fn test_normalize_keypath(#[case] input: &str, #[case] expected: (&str, &str)) {
         let res = crate::enc_mods::normalize_path(input).expect("normalize failed");
         assert_eq!(res.0, expected.0);
         assert_eq!(res.1, expected.1);
+    }
+
+    #[rstest]
+    #[case(
+        "kbs+pkcs11:///slot/key/label/version",
+        "",
+        "slot/key/label/version",
+        "kbs+pkcs11:///slot/key/label/version"
+    )]
+    #[case(
+        "kbs+resource:///repo/type/tag",
+        "",
+        "repo/type/tag",
+        "kbs:///repo/type/tag"
+    )]
+    #[case("/repo/type/tag", "", "repo/type/tag", "kbs:///repo/type/tag")]
+    fn annotation_keeps_plugin_and_canonicalizes_legacy_paths(
+        #[case] input: &str,
+        #[case] address: &str,
+        #[case] path: &str,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(
+            crate::enc_mods::normalized_annotation_kid(input, address, path),
+            expected
+        );
     }
 }

--- a/attestation-agent/deps/resource_uri/src/lib.rs
+++ b/attestation-agent/deps/resource_uri/src/lib.rs
@@ -3,26 +3,36 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-//! ResourceUri is the identification information of all resources that need to be
-//! obtained from `get_resource` endpoint. Also, `kid` field in an
-//! [`super::AnnotationPacket`] of `decrypt_payload` should also follow this.
+//! Resource URI parsing for resources obtained from Trustee.
 
 use anyhow::{anyhow, bail, Result};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 const RESOURCE_ID_ERROR_INFO: &str =
-    "invalid kbs resource uri, should be kbs://<addr-of-kbs>/<repo>/<type>/<tag>";
+    "invalid KBS resource URI, expected kbs[+plugin]://<kbs-address>/<path>";
 
 const SCHEME: &str = "kbs";
+pub const DEFAULT_RESOURCE_PLUGIN: &str = "resource";
 
-/// Resource Id document <https://github.com/confidential-containers/guest-components/blob/main/attestation-agent/docs/KBS_URI.md>
+/// Identifies a resource exposed by a Trustee plugin.
+///
+/// The default `kbs://` scheme addresses the `resource` plugin. Other plugins
+/// use `kbs+<plugin>://`, and their resource paths may contain any positive
+/// number of segments.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ResourceUri {
-    pub kbs_addr: String,
-    pub repository: String,
+    pub kbs_address: String,
+    pub plugin: String,
+    pub path: Vec<String>,
+    pub query: Option<String>,
+}
+
+/// The three-segment path required by Trustee's default `resource` plugin.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResourcePluginPath {
+    pub repo: String,
     pub r#type: String,
     pub tag: String,
-    pub query: Option<String>,
 }
 
 impl TryFrom<&str> for ResourceUri {
@@ -38,174 +48,270 @@ impl TryFrom<url::Url> for ResourceUri {
     type Error = &'static str;
 
     fn try_from(value: url::Url) -> Result<Self, Self::Error> {
-        let mut addr = value.host_str().unwrap_or_default().to_string();
+        let mut kbs_address = value.host_str().unwrap_or_default().to_string();
 
-        if !addr.is_empty() {
+        if !kbs_address.is_empty() {
             if let Some(port) = value.port() {
-                addr += ":";
-                addr += &port.to_string();
+                kbs_address.push(':');
+                kbs_address.push_str(&port.to_string());
             }
         }
 
-        if value.scheme() != SCHEME {
-            return Err("scheme must be kbs");
-        }
+        let plugin = match value.scheme() {
+            SCHEME => DEFAULT_RESOURCE_PLUGIN.to_string(),
+            scheme if scheme.starts_with("kbs+") => {
+                let plugin = scheme.trim_start_matches("kbs+");
+                if plugin.is_empty() {
+                    return Err("scheme kbs+ requires a plugin name, e.g. kbs+pkcs11");
+                }
+                plugin.to_string()
+            }
+            _ => return Err("scheme must be kbs or kbs+<plugin>"),
+        };
 
-        if value.path().is_empty() {
-            return Err(RESOURCE_ID_ERROR_INFO);
-        }
+        let path = value.path().strip_prefix('/').unwrap_or(value.path());
+        let path = parse_path(path)?;
 
-        let path = &value.path()[1..];
-        let values: Vec<&str> = path.split('/').collect();
-        if values.len() == 3 {
-            Ok(Self {
-                kbs_addr: addr,
-                repository: values[0].into(),
-                r#type: values[1].into(),
-                tag: values[2].into(),
-                query: value.query().map(|s| s.to_string()),
-            })
-        } else {
-            Err(RESOURCE_ID_ERROR_INFO)
-        }
+        Ok(Self {
+            kbs_address,
+            plugin,
+            path,
+            query: value.query().map(ToString::to_string),
+        })
     }
 }
 
 impl From<ResourceUri> for url::Url {
-    fn from(val: ResourceUri) -> Self {
-        url::Url::try_from(&val.whole_uri()[..]).expect("unexpected parse")
+    fn from(value: ResourceUri) -> Self {
+        url::Url::try_from(value.whole_uri().as_str()).expect("unexpected resource URI parse")
+    }
+}
+
+impl TryFrom<ResourceUri> for ResourcePluginPath {
+    type Error = anyhow::Error;
+
+    fn try_from(value: ResourceUri) -> Result<Self, Self::Error> {
+        Self::try_from(&value)
+    }
+}
+
+impl TryFrom<&ResourceUri> for ResourcePluginPath {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &ResourceUri) -> Result<Self, Self::Error> {
+        if value.plugin != DEFAULT_RESOURCE_PLUGIN {
+            bail!(
+                "resource URI plugin must be {DEFAULT_RESOURCE_PLUGIN} instead of {}",
+                value.plugin
+            );
+        }
+
+        if value.path.len() != 3 {
+            bail!(
+                "resource URI path must contain 3 segments instead of {}",
+                value.path.len()
+            );
+        }
+
+        Ok(Self {
+            repo: value.path[0].clone(),
+            r#type: value.path[1].clone(),
+            tag: value.path[2].clone(),
+        })
     }
 }
 
 impl ResourceUri {
-    pub fn new(kbs_uri: &str, resource_path: &str) -> Result<Self> {
-        let kbs_addr = match url::Url::parse(kbs_uri) {
+    pub fn new(
+        kbs_uri: &str,
+        resource_path: &str,
+        plugin: Option<&str>,
+        query: Option<&str>,
+    ) -> Result<Self> {
+        let kbs_address = match url::Url::parse(kbs_uri) {
             Ok(url) => {
-                let kbs_host = url
+                let host = url
                     .host_str()
-                    .ok_or_else(|| anyhow!("Invalid URL: {}", url))?;
+                    .ok_or_else(|| anyhow!("Invalid URL: {url}"))?;
 
-                if let Some(port) = url.port() {
-                    format!("{kbs_host}:{port}")
-                } else {
-                    kbs_host.to_string()
+                match url.port() {
+                    Some(port) => format!("{host}:{port}"),
+                    None => host.to_string(),
                 }
             }
             Err(_) => kbs_uri.to_string(),
         };
 
-        if !resource_path.starts_with('/') {
-            bail!("Resource path {resource_path} must start with '/'")
-        }
+        let path = resource_path
+            .strip_prefix('/')
+            .ok_or_else(|| anyhow!("Resource path {resource_path} must start with '/'"))?;
 
-        let values: Vec<&str> = resource_path.split('/').collect();
-        if values.len() == 4 {
-            Ok(Self {
-                kbs_addr,
-                repository: values[1].into(),
-                r#type: values[2].into(),
-                tag: values[3].into(),
-                query: None,
-            })
-        } else {
-            bail!(
-                "Resource path {resource_path} must follow the format '/<repository>/<type>/<tag>'"
-            )
-        }
+        Ok(Self {
+            kbs_address,
+            plugin: plugin.unwrap_or(DEFAULT_RESOURCE_PLUGIN).to_string(),
+            path: parse_path(path).map_err(anyhow::Error::msg)?,
+            query: query.map(ToString::to_string),
+        })
     }
 
     pub fn whole_uri(&self) -> String {
-        let uri = format!(
-            "{SCHEME}://{}/{}/{}/{}",
-            self.kbs_addr, self.repository, self.r#type, self.tag
-        );
+        let scheme = match self.plugin.as_str() {
+            DEFAULT_RESOURCE_PLUGIN => SCHEME.to_string(),
+            plugin => format!("{SCHEME}+{plugin}"),
+        };
+        let uri = format!("{scheme}://{}/{}", self.kbs_address, self.resource_path());
+
         match &self.query {
-            Some(q) => format!("{uri}?{q}"),
+            Some(query) => format!("{uri}?{query}"),
             None => uri,
         }
     }
 
-    /// Only return the resource path. This function is used
-    /// currently because up to now the kbs-uri is given
-    /// to create an AA instance.
+    /// Returns the Trustee plugin name. `kbs://` maps to `resource`.
+    pub fn plugin(&self) -> &str {
+        &self.plugin
+    }
+
+    /// Returns the slash-separated path sent to the Trustee plugin.
     pub fn resource_path(&self) -> String {
-        format!("{}/{}/{}", self.repository, self.r#type, self.tag)
+        self.path.join("/")
     }
 }
 
+fn parse_path(path: &str) -> std::result::Result<Vec<String>, &'static str> {
+    if path.is_empty() {
+        return Err(RESOURCE_ID_ERROR_INFO);
+    }
+
+    let segments: Vec<String> = path.split('/').map(ToString::to_string).collect();
+    if segments.iter().any(|segment| segment.is_empty()) {
+        return Err("resource URI path must not contain empty segments");
+    }
+
+    Ok(segments)
+}
+
 impl Serialize for ResourceUri {
-    fn serialize<S>(&self, ser: S) -> ::std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let url = self.whole_uri();
-        ser.serialize_str(&url)
+        serializer.serialize_str(&self.whole_uri())
     }
 }
 
 impl<'de> Deserialize<'de> for ResourceUri {
-    fn deserialize<D: Deserializer<'de>>(de: D) -> ::std::result::Result<Self, D::Error> {
-        let intermediate: &str = Deserialize::deserialize(de)?;
-        intermediate
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+        let value: &str = Deserialize::deserialize(deserializer)?;
+        value
             .try_into()
-            .map_err(|e| serde::de::Error::custom(format!("{e:?}")))
+            .map_err(|error| serde::de::Error::custom(format!("{error:?}")))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::ResourceUri;
+    use super::{ResourcePluginPath, ResourceUri, DEFAULT_RESOURCE_PLUGIN};
     use rstest::rstest;
 
     #[rstest]
-    #[case("kbs:///alice/cosign-key/213", "alice", "cosign-key", "213", None)]
     #[case(
-        "kbs:///plugin/plugname/resourcename?param1=value1&param2=value2",
-        "plugin",
-        "plugname",
-        "resourcename",
+        "kbs:///alice/cosign-key/213",
+        "",
+        "resource",
+        "alice/cosign-key/213",
+        None
+    )]
+    #[case(
+        "kbs:///repo/type/tag?param1=value1&param2=value2",
+        "",
+        "resource",
+        "repo/type/tag",
         Some("param1=value1&param2=value2")
     )]
-    fn test_resource_uri_serialization_conversion(
-        #[case] url: &str,
-        #[case] repository: &str,
-        #[case] r#type: &str,
-        #[case] tag: &str,
+    #[case("kbs+pkcs11:///slot/key/label", "", "pkcs11", "slot/key/label", None)]
+    #[case(
+        "kbs+custom://example.com:8080/a/b/c/d/e",
+        "example.com:8080",
+        "custom",
+        "a/b/c/d/e",
+        None
+    )]
+    fn serialization_round_trip(
+        #[case] uri: &str,
+        #[case] address: &str,
+        #[case] plugin: &str,
+        #[case] path: &str,
         #[case] query: Option<&str>,
     ) {
-        let resource = ResourceUri {
-            kbs_addr: "".into(),
-            repository: repository.into(),
-            r#type: r#type.into(),
-            tag: tag.into(),
-            query: query.map(|s| s.to_string()),
-        };
+        let parsed: ResourceUri = uri.try_into().expect("parse resource URI");
+        assert_eq!(parsed.kbs_address, address);
+        assert_eq!(parsed.plugin(), plugin);
+        assert_eq!(parsed.resource_path(), path);
+        assert_eq!(parsed.query.as_deref(), query);
+        assert_eq!(parsed.whole_uri(), uri);
+        assert_eq!(
+            serde_json::to_string(&parsed).unwrap(),
+            format!("\"{uri}\"")
+        );
 
-        // Deserialization
-        let deserialized: ResourceUri =
-            serde_json::from_str(&format!("\"{url}\"")).expect("deserialize failed");
-        assert_eq!(deserialized, resource);
-
-        // Serialization
-        let serialized = serde_json::to_string(&resource).expect("deserialize failed");
-        assert_eq!(serialized, format!("\"{url}\""));
-
-        // Conversion to Url
-        let url_from_string = url::Url::try_from(url).expect("failed to parse url");
-        let url_from_resource: url::Url =
-            resource.clone().try_into().expect("failed to try into url");
-        assert_eq!(url_from_string, url_from_resource);
-
-        // Conversion to ResourceUri
-        let resource_from_url =
-            ResourceUri::try_from(url_from_string).expect("failed to try from url");
-        assert_eq!(resource_from_url, resource);
+        let as_url: url::Url = parsed.clone().into();
+        let from_url = ResourceUri::try_from(as_url).expect("parse URL");
+        assert_eq!(from_url, parsed);
     }
 
     #[test]
-    fn test_resource_path() {
-        let resource = ResourceUri::new("https://kbs.example.com/", "/repo/type/tag").unwrap();
+    fn default_resource_plugin_has_canonical_short_form() {
+        let shorthand: ResourceUri = "kbs:///repo/type/tag".try_into().unwrap();
+        let explicit: ResourceUri = "kbs+resource:///repo/type/tag".try_into().unwrap();
 
-        assert_eq!(resource.resource_path(), "repo/type/tag".to_string());
+        assert_eq!(shorthand, explicit);
+        assert_eq!(explicit.plugin(), DEFAULT_RESOURCE_PLUGIN);
+        assert_eq!(explicit.whole_uri(), "kbs:///repo/type/tag");
+    }
+
+    #[rstest]
+    #[case("http:///repo/type/tag", "scheme must be kbs")]
+    #[case("kbs+:///repo/type/tag", "requires a plugin name")]
+    #[case("kbs://example.com", "expected kbs")]
+    #[case("kbs:///repo//tag", "empty segments")]
+    fn rejects_invalid_uri(#[case] uri: &str, #[case] expected: &str) {
+        let error = ResourceUri::try_from(uri).unwrap_err();
+        assert!(error.contains(expected), "unexpected error: {error}");
+    }
+
+    #[test]
+    fn constructor_keeps_one_path_separator() {
+        let uri = ResourceUri::new(
+            "https://kbs.example.com:8443/",
+            "/repo/type/tag",
+            Some("pkcs11"),
+            Some("slot=1"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            uri.whole_uri(),
+            "kbs+pkcs11://kbs.example.com:8443/repo/type/tag?slot=1"
+        );
+    }
+
+    #[test]
+    fn converts_only_default_three_segment_resource_paths() {
+        let uri: ResourceUri = "kbs:///repo/type/tag".try_into().unwrap();
+        assert_eq!(
+            ResourcePluginPath::try_from(&uri).unwrap(),
+            ResourcePluginPath {
+                repo: "repo".into(),
+                r#type: "type".into(),
+                tag: "tag".into(),
+            }
+        );
+
+        let plugin_uri: ResourceUri = "kbs+pkcs11:///repo/type/tag".try_into().unwrap();
+        assert!(ResourcePluginPath::try_from(plugin_uri).is_err());
+
+        let long_uri: ResourceUri = "kbs:///repo/type/tag/extra".try_into().unwrap();
+        assert!(ResourcePluginPath::try_from(long_uri).is_err());
     }
 }

--- a/attestation-agent/docs/KBS_URI.md
+++ b/attestation-agent/docs/KBS_URI.md
@@ -1,36 +1,67 @@
 # KBS Resource URI
 
-## Introduction
+## Format
 
-To uniquely identify every resource/key in the CoCo Key Broker System, a __KBS Resource URI__ is defined.
+A Resource URI identifies a path exposed by a Trustee plugin:
 
-## Specification
-
-A KBS Resource URI must comply with the following format:
-
-```plaintext
-kbs://<kbs_host>:<kbs_port>/<repository>/<type>/<tag>
+```text
+kbs[+<plugin>]://<kbs-host>:<kbs-port>/<segment>[/<segment>...][?<query>]
 ```
 
-where:
+- `kbs://` is the canonical shorthand for Trustee's default `resource` plugin.
+- `kbs+<plugin>://` selects another plugin, for example `kbs+pkcs11://`.
+- The host and port are optional because the active KBC configuration selects
+  the Trustee endpoint. Omitting them produces three slashes, such as
+  `kbs:///default/key/1`.
+- A path has one or more non-empty slash-separated segments. It is not limited
+  to the three `repository/type/tag` segments used by the default resource
+  plugin.
+- An optional query string is forwarded unchanged to Trustee.
 
-- `kbs://`: This is the fixed, custom KBS resource scheme. It indicates that this URI for a [CoCo KBS](https://github.com/confidential-containers/kbs/tree/main/kbs) resource.
-- `<kbs_host>:<kbs_port>`: This the KBS host address and port. It is either an IP address or a domain name, and an *optional* TCP/UDP port. Also can be treated as a `confidential resource registry`.
-- `<repository>/<type>/<tag>`: This is the resource path. Typically, `<repository>` would be a user name, `<type>` would be the type of the resource, and `<tag>` would help distinguish between different resource instances of the same type. The default value of `<repository>` is `default`.
+`kbs+resource://` and `kbs://` have identical meaning. Serialization uses the
+shorter `kbs://` form for the default plugin.
 
-For example: `kbs://example.cckbs.org:8081/alice/decryption-key/1`
+## Examples
 
-## How Different KBC/KBS uses a KBS Resource URI
+```text
+kbs:///default/key/1
+kbs://example.cckbs.org:8081/alice/decryption-key/1
+kbs+pkcs11:///slot/token/private-key/version
+kbs+nebula-ca:///cluster/node?duration=3600
+```
 
-### CC-KBC
+## Trustee request mapping
 
-`CC-KBC` will convert a KBS Resource URI into a [CoCo KBS Resource API](https://github.com/confidential-containers/kbs/blob/main/kbs/docs/kbs.yaml#L100) compliant HTTP/HTTPS request.
-For example, a KBS Resource URI `kbs://example.cckbs.org/alice/decryption-key/1` will be converted to `http://example.cckbs.org/kbs/v0/resource/alice/decryption-key/1`.
+The KBS client maps a Resource URI to the OpenAnolis Trustee route:
 
-### EAA KBC & Online SEV KBC
+```text
+<trustee-base-url>/kbs/v0/<plugin>/<segment1>/<segment2>/...
+```
 
-Both KBCs will use the `<repository>/<type>/<tag>` as key/resource id in their requests.
+For example:
 
-### Offline KBCs (e.g FS KBC & Offline SEV KBC)
+```text
+kbs://example.cckbs.org:8081/alice/decryption-key/1
+```
 
-Offline KBCs should ignore the `<kbs_host>:<kbs_port>` host part of the URI, and use the resource path (`<repository>/<type>/<tag>`) to locally fetch the resource.
+maps to:
+
+```text
+http://example.cckbs.org:8081/kbs/v0/resource/alice/decryption-key/1
+```
+
+and:
+
+```text
+kbs+pkcs11:///slot/token/private-key/version?pin-source=file
+```
+
+maps to:
+
+```text
+<trustee-base-url>/kbs/v0/pkcs11/slot/token/private-key/version?pin-source=file
+```
+
+Offline, sample, and online-SEV KBC implementations only understand the
+three-segment default `resource` plugin path. They reject other plugins or path
+shapes explicitly instead of silently routing them incorrectly.

--- a/attestation-agent/kbc/src/offline_fs_kbc/mod.rs
+++ b/attestation-agent/kbc/src/offline_fs_kbc/mod.rs
@@ -8,11 +8,11 @@ use crate::{KbcCheckInfo, KbcInterface};
 pub mod common;
 use common::*;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use base64::Engine;
 use crypto::WrapType;
-use resource_uri::ResourceUri;
+use resource_uri::{ResourcePluginPath, ResourceUri};
 use std::collections::HashMap;
 use zeroize::Zeroizing;
 
@@ -51,8 +51,11 @@ impl KbcInterface for OfflineFsKbc {
         Ok(plain_payload)
     }
 
-    async fn get_resource(&mut self, rid: ResourceUri) -> Result<Vec<u8>> {
-        let resource_path = rid.resource_path();
+    async fn get_resource(&mut self, resource_uri: ResourceUri) -> Result<Vec<u8>> {
+        let ResourcePluginPath { repo, r#type, tag } = resource_uri
+            .try_into()
+            .context("offline FS KBC only supports the resource plugin")?;
+        let resource_path = format!("{repo}/{type}/{tag}");
         let resources = self.resources.as_ref().map_err(|e| anyhow!("{}", e))?;
         let resource = resources
             .get(resource_path.as_str())
@@ -146,6 +149,7 @@ mod tests {
     #[case(true, ResourcePath::Credential.as_ref(), CREDENTIAL)]
     // Case 2. Error while get bad resource name from a good kbc instance
     #[case(false, "kbs:///default/credential/not-existed", "")]
+    #[case(false, "kbs+pkcs11:///default/credential/test", "")]
     #[tokio::test]
     async fn test_get_resource(
         #[case] success: bool,

--- a/attestation-agent/kbc/src/online_sev_kbc/mod.rs
+++ b/attestation-agent/kbc/src/online_sev_kbc/mod.rs
@@ -7,7 +7,7 @@ use crate::{KbcCheckInfo, KbcInterface};
 use ::sev::*;
 use base64::Engine;
 use crypto::WrapType;
-use resource_uri::ResourceUri;
+use resource_uri::{ResourcePluginPath, ResourceUri};
 
 use anyhow::*;
 use async_trait::async_trait;
@@ -62,8 +62,11 @@ impl KbcInterface for OnlineSevKbc {
         Ok(plain_payload)
     }
 
-    async fn get_resource(&mut self, rid: ResourceUri) -> Result<Vec<u8>> {
-        match &rid.r#type[..] {
+    async fn get_resource(&mut self, resource_uri: ResourceUri) -> Result<Vec<u8>> {
+        let ResourcePluginPath { repo, r#type, tag } = resource_uri
+            .try_into()
+            .context("online SEV KBC only supports the resource plugin")?;
+        match r#type.as_str() {
             "client-id" => {
                 let connection = self
                     .connection
@@ -71,7 +74,7 @@ impl KbcInterface for OnlineSevKbc {
                     .map_err(|e| anyhow!("Failed to get injected connection. {}", e))?;
                 Ok(connection.client_id.hyphenated().to_string().into_bytes())
             }
-            _ => self.get_resource_from_kbs(rid).await,
+            _ => self.get_resource_from_kbs(&repo, &r#type, &tag).await,
         }
     }
 }
@@ -135,8 +138,8 @@ impl OnlineSevKbc {
         Ok(key)
     }
 
-    async fn get_resource_from_kbs(&self, rid: ResourceUri) -> Result<Vec<u8>> {
-        self.query_kbs("resource".to_string(), rid.resource_path())
+    async fn get_resource_from_kbs(&self, repo: &str, r#type: &str, tag: &str) -> Result<Vec<u8>> {
+        self.query_kbs("resource".to_string(), format!("{repo}/{type}/{tag}"))
             .await
     }
 }

--- a/attestation-agent/kbc/src/sample_kbc/mod.rs
+++ b/attestation-agent/kbc/src/sample_kbc/mod.rs
@@ -6,7 +6,7 @@
 use crate::{KbcCheckInfo, KbcInterface};
 use base64::Engine;
 use crypto::{decrypt, WrapType};
-use resource_uri::ResourceUri;
+use resource_uri::{ResourcePluginPath, ResourceUri};
 
 use anyhow::*;
 use async_trait::async_trait;
@@ -75,8 +75,11 @@ impl KbcInterface for SampleKbc {
         Ok(plain_text)
     }
 
-    async fn get_resource(&mut self, rid: ResourceUri) -> Result<Vec<u8>> {
-        let typ = ResourceType::try_from(&rid.r#type[..])?;
+    async fn get_resource(&mut self, resource_uri: ResourceUri) -> Result<Vec<u8>> {
+        let ResourcePluginPath { r#type, .. } = resource_uri
+            .try_into()
+            .context("sample KBC only supports the resource plugin")?;
+        let typ = ResourceType::try_from(r#type.as_str())?;
         match typ {
             ResourceType::Policy => Ok(std::include_str!("policy.json").as_bytes().to_vec()),
             ResourceType::SigstoreConfig => Ok(std::include_str!("sigstore_config.yaml")

--- a/attestation-agent/kbs_protocol/Cargo.toml
+++ b/attestation-agent/kbs_protocol/Cargo.toml
@@ -35,7 +35,14 @@ rstest.workspace = true
 serial_test.workspace = true
 tempfile.workspace = true
 testcontainers.workspace = true
-tokio = { workspace = true, features = ["rt", "macros", "fs", "process"] }
+tokio = { workspace = true, features = [
+    "rt",
+    "macros",
+    "fs",
+    "process",
+    "net",
+    "io-util",
+] }
 
 [build-dependencies]
 

--- a/attestation-agent/kbs_protocol/src/bin/trustee-attester/main.rs
+++ b/attestation-agent/kbs_protocol/src/bin/trustee-attester/main.rs
@@ -5,7 +5,7 @@
 
 //! Attest and fetch confidential resources from Trustee
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
 use clap::{Parser, Subcommand};
@@ -74,12 +74,18 @@ async fn main() -> Result<()> {
 
     match cli.command {
         Commands::GetResource { path } => {
-            // resource_path should start with '/' but not with '//'
-            let resource_path = match path.starts_with('/') {
-                false => format!("/{}", path),
-                true => path,
+            let resource = if path.contains("://") {
+                ResourceUri::try_from(path.as_str())
+                    .map_err(anyhow::Error::msg)
+                    .context("failed to parse resource URI")?
+            } else {
+                // A bare path continues to address the default resource plugin.
+                let resource_path = match path.starts_with('/') {
+                    false => format!("/{path}"),
+                    true => path,
+                };
+                ResourceUri::new("", &resource_path, None, None)?
             };
-            let resource = ResourceUri::new("", &resource_path)?;
             let resource_bytes = client.get_resource(resource).await?;
 
             println!("{}", STANDARD.encode(resource_bytes));

--- a/attestation-agent/kbs_protocol/src/client/mod.rs
+++ b/attestation-agent/kbs_protocol/src/client/mod.rs
@@ -19,10 +19,11 @@ pub mod rcar_client;
 #[cfg(feature = "passport")]
 pub mod token_client;
 
-use kbs_types::Tee;
+use kbs_types::{Response, Tee};
+use reqwest::header::CONTENT_TYPE;
 use resource_uri::ResourceUri;
 
-use crate::{keypair::TeeKeyPair, token_provider::Token};
+use crate::{keypair::TeeKeyPair, token_provider::Token, Error, Result};
 
 pub(crate) enum ClientTee {
     Uninitialized,
@@ -58,6 +59,50 @@ pub const KBS_GET_RESOURCE_MAX_ATTEMPT: u64 = 3;
 
 pub const KBS_PREFIX: &str = "kbs/v0";
 
+impl<T> KbsClient<T> {
+    /// Decode a successful plugin response according to Trustee's response
+    /// contract. Encrypted plugin responses use the KBS JWE JSON envelope;
+    /// plaintext plugins use a non-JSON content type and return their bytes
+    /// directly.
+    async fn decode_resource_response(&self, response: reqwest::Response) -> Result<Vec<u8>> {
+        let content_type = response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok());
+
+        if !is_encrypted_resource_response(content_type) {
+            return response
+                .bytes()
+                .await
+                .map(|body| body.to_vec())
+                .map_err(|error| Error::KbsResponseDeserializationFailed(error.to_string()));
+        }
+
+        let response = response
+            .json::<Response>()
+            .await
+            .map_err(|error| Error::KbsResponseDeserializationFailed(error.to_string()))?;
+        self.tee_key
+            .decrypt_response(response)
+            .map_err(|error| Error::DecryptResponseFailed(error.to_string()))
+    }
+}
+
+fn is_encrypted_resource_response(content_type: Option<&str>) -> bool {
+    // KBS resource responses historically omitted Content-Type in some
+    // deployments, so keep the encrypted JWE behavior as the safe default.
+    content_type
+        .map(|value| {
+            value
+                .split(';')
+                .next()
+                .unwrap_or_default()
+                .trim()
+                .eq_ignore_ascii_case("application/json")
+        })
+        .unwrap_or(true)
+}
+
 pub(crate) fn resource_url(kbs_host_url: &str, resource_uri: &ResourceUri) -> String {
     let mut url = format!(
         "{}/{KBS_PREFIX}/{}/{}",
@@ -76,9 +121,19 @@ pub(crate) fn resource_url(kbs_host_url: &str, resource_uri: &ResourceUri) -> St
 
 #[cfg(test)]
 mod tests {
-    use super::resource_url;
+    use super::{is_encrypted_resource_response, resource_url};
     use resource_uri::ResourceUri;
     use rstest::rstest;
+
+    #[cfg(feature = "background_check")]
+    use {
+        crate::{
+            evidence_provider::{mock::MockedEvidenceProvider, EvidenceProvider},
+            KbsClientBuilder, KbsClientCapabilities,
+        },
+        tokio::io::{AsyncReadExt, AsyncWriteExt},
+        tokio::net::TcpListener,
+    };
 
     #[rstest]
     #[case(
@@ -98,5 +153,54 @@ mod tests {
     ) {
         let resource_uri = ResourceUri::try_from(uri).unwrap();
         assert_eq!(resource_url(base, &resource_uri), expected);
+    }
+
+    #[rstest]
+    #[case(None, true)]
+    #[case(Some("application/json"), true)]
+    #[case(Some("application/json; charset=utf-8"), true)]
+    #[case(Some("text/xml"), false)]
+    #[case(Some("application/octet-stream"), false)]
+    fn classifies_encrypted_and_plaintext_plugin_responses(
+        #[case] content_type: Option<&str>,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(is_encrypted_resource_response(content_type), expected);
+    }
+
+    #[cfg(feature = "background_check")]
+    #[tokio::test]
+    async fn returns_plaintext_plugin_response_with_arbitrary_path_and_query() {
+        const BODY: &[u8] = b"sample plugin response";
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4096];
+            let bytes_read = stream.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..bytes_read]);
+            assert!(request
+                .starts_with("GET /kbs/v0/sample/path/with/arbitrary/depth?mode=test HTTP/1.1"));
+
+            let headers = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: text/xml\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                BODY.len()
+            );
+            stream.write_all(headers.as_bytes()).await.unwrap();
+            stream.write_all(BODY).await.unwrap();
+        });
+
+        let provider: Box<dyn EvidenceProvider> = Box::new(MockedEvidenceProvider::default());
+        let mut client =
+            KbsClientBuilder::with_evidence_provider(provider, &format!("http://{address}"))
+                .build()
+                .unwrap();
+        let resource_uri =
+            ResourceUri::try_from("kbs+sample:///path/with/arbitrary/depth?mode=test").unwrap();
+
+        let response = client.get_resource(resource_uri).await.unwrap();
+        server.await.unwrap();
+        assert_eq!(response, BODY);
     }
 }

--- a/attestation-agent/kbs_protocol/src/client/mod.rs
+++ b/attestation-agent/kbs_protocol/src/client/mod.rs
@@ -20,6 +20,7 @@ pub mod rcar_client;
 pub mod token_client;
 
 use kbs_types::Tee;
+use resource_uri::ResourceUri;
 
 use crate::{keypair::TeeKeyPair, token_provider::Token};
 
@@ -56,3 +57,46 @@ pub const KBS_PROTOCOL_VERSION: &str = "0.4.0";
 pub const KBS_GET_RESOURCE_MAX_ATTEMPT: u64 = 3;
 
 pub const KBS_PREFIX: &str = "kbs/v0";
+
+pub(crate) fn resource_url(kbs_host_url: &str, resource_uri: &ResourceUri) -> String {
+    let mut url = format!(
+        "{}/{KBS_PREFIX}/{}/{}",
+        kbs_host_url.trim_end_matches('/'),
+        resource_uri.plugin(),
+        resource_uri.resource_path(),
+    );
+
+    if let Some(query) = &resource_uri.query {
+        url.push('?');
+        url.push_str(query);
+    }
+
+    url
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resource_url;
+    use resource_uri::ResourceUri;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(
+        "https://kbs.example.com/",
+        "kbs:///repo/type/tag",
+        "https://kbs.example.com/kbs/v0/resource/repo/type/tag"
+    )]
+    #[case(
+        "https://kbs.example.com",
+        "kbs+pkcs11:///slot/key/label/version?pin-source=file",
+        "https://kbs.example.com/kbs/v0/pkcs11/slot/key/label/version?pin-source=file"
+    )]
+    fn builds_openanolis_trustee_plugin_route(
+        #[case] base: &str,
+        #[case] uri: &str,
+        #[case] expected: &str,
+    ) {
+        let resource_uri = ResourceUri::try_from(uri).unwrap();
+        assert_eq!(resource_url(base, &resource_uri), expected);
+    }
+}

--- a/attestation-agent/kbs_protocol/src/client/rcar_client.rs
+++ b/attestation-agent/kbs_protocol/src/client/rcar_client.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use attester::TeeEvidence;
 use canon_json::CanonicalFormatter;
 use kbs_types::HashAlgorithm;
-use kbs_types::{Attestation, Challenge, ErrorInformation, Request, Response, Tee, TeePubKey};
+use kbs_types::{Attestation, Challenge, ErrorInformation, Request, Tee, TeePubKey};
 use log::{debug, warn};
 use resource_uri::ResourceUri;
 use serde::{Deserialize, Serialize};
@@ -370,15 +370,7 @@ impl KbsClientCapabilities for KbsClient<Box<dyn EvidenceProvider>> {
 
             match res.status() {
                 reqwest::StatusCode::OK => {
-                    let response = res
-                        .json::<Response>()
-                        .await
-                        .map_err(|e| Error::KbsResponseDeserializationFailed(e.to_string()))?;
-                    let payload_data = self
-                        .tee_key
-                        .decrypt_response(response)
-                        .map_err(|e| Error::DecryptResponseFailed(e.to_string()))?;
-                    return Ok(payload_data);
+                    return self.decode_resource_response(res).await;
                 }
                 reqwest::StatusCode::UNAUTHORIZED => {
                     warn!(

--- a/attestation-agent/kbs_protocol/src/client/rcar_client.rs
+++ b/attestation-agent/kbs_protocol/src/client/rcar_client.rs
@@ -19,7 +19,8 @@ use serde_json::json;
 use crate::{
     api::KbsClientCapabilities,
     client::{
-        ClientTee, KbsClient, KBS_GET_RESOURCE_MAX_ATTEMPT, KBS_PREFIX, KBS_PROTOCOL_VERSION,
+        resource_url, ClientTee, KbsClient, KBS_GET_RESOURCE_MAX_ATTEMPT, KBS_PREFIX,
+        KBS_PROTOCOL_VERSION,
     },
     evidence_provider::EvidenceProvider,
     keypair::TeeKeyPair,
@@ -341,13 +342,7 @@ impl KbsClient<Box<dyn EvidenceProvider>> {
 #[async_trait]
 impl KbsClientCapabilities for KbsClient<Box<dyn EvidenceProvider>> {
     async fn get_resource(&mut self, resource_uri: ResourceUri) -> Result<Vec<u8>> {
-        let mut remote_url = format!(
-            "{}/{KBS_PREFIX}/resource/{}/{}/{}",
-            self.kbs_host_url, resource_uri.repository, resource_uri.r#type, resource_uri.tag
-        );
-        if let Some(ref q) = resource_uri.query {
-            remote_url = format!("{remote_url}?{q}");
-        }
+        let remote_url = resource_url(&self.kbs_host_url, &resource_uri);
 
         for attempt in 1..=KBS_GET_RESOURCE_MAX_ATTEMPT {
             debug!("KBS client: trying to request KBS, attempt {attempt}");

--- a/attestation-agent/kbs_protocol/src/client/token_client.rs
+++ b/attestation-agent/kbs_protocol/src/client/token_client.rs
@@ -6,7 +6,7 @@
 use std::env;
 
 use async_trait::async_trait;
-use kbs_types::{ErrorInformation, Response};
+use kbs_types::ErrorInformation;
 use log::{debug, warn};
 use resource_uri::ResourceUri;
 
@@ -65,15 +65,7 @@ impl KbsClientCapabilities for KbsClient<Box<dyn TokenProvider>> {
 
             match res.status() {
                 reqwest::StatusCode::OK => {
-                    let response = res
-                        .json::<Response>()
-                        .await
-                        .map_err(|e| Error::KbsResponseDeserializationFailed(e.to_string()))?;
-                    let payload_data = self
-                        .tee_key
-                        .decrypt_response(response)
-                        .map_err(|e| Error::DecryptResponseFailed(e.to_string()))?;
-                    return Ok(payload_data);
+                    return self.decode_resource_response(res).await;
                 }
                 reqwest::StatusCode::UNAUTHORIZED => {
                     warn!(

--- a/attestation-agent/kbs_protocol/src/client/token_client.rs
+++ b/attestation-agent/kbs_protocol/src/client/token_client.rs
@@ -12,7 +12,7 @@ use resource_uri::ResourceUri;
 
 use crate::{
     api::KbsClientCapabilities,
-    client::{KbsClient, KBS_GET_RESOURCE_MAX_ATTEMPT, KBS_PREFIX},
+    client::{resource_url, KbsClient, KBS_GET_RESOURCE_MAX_ATTEMPT},
     token_provider::TokenProvider,
     Error, Result,
 };
@@ -45,13 +45,7 @@ impl KbsClient<Box<dyn TokenProvider>> {
 #[async_trait]
 impl KbsClientCapabilities for KbsClient<Box<dyn TokenProvider>> {
     async fn get_resource(&mut self, resource_uri: ResourceUri) -> Result<Vec<u8>> {
-        let mut remote_url = format!(
-            "{}/{KBS_PREFIX}/resource/{}/{}/{}",
-            self.kbs_host_url, resource_uri.repository, resource_uri.r#type, resource_uri.tag
-        );
-        if let Some(ref q) = resource_uri.query {
-            remote_url = format!("{}?{}", remote_url, q);
-        }
+        let remote_url = resource_url(&self.kbs_host_url, &resource_uri);
 
         for attempt in 1..=KBS_GET_RESOURCE_MAX_ATTEMPT {
             debug!("KBS client: trying to request KBS, attempt {attempt}");

--- a/attestation-agent/kbs_protocol/src/evidence_provider/aa_ttrpc.rs
+++ b/attestation-agent/kbs_protocol/src/evidence_provider/aa_ttrpc.rs
@@ -29,8 +29,12 @@ pub struct AAEvidenceProvider {
 
 impl AAEvidenceProvider {
     pub async fn new() -> Result<Self> {
-        let c = ttrpc::r#async::Client::connect(AA_SOCKET_FILE)
-            .map_err(|e| Error::AATokenProvider(format!("ttrpc connect failed {e}")))?;
+        Self::new_with_socket(AA_SOCKET_FILE).await
+    }
+
+    pub async fn new_with_socket(aa_socket: &str) -> Result<Self> {
+        let c = ttrpc::r#async::Client::connect(aa_socket)
+            .map_err(|e| Error::AAEvidenceProvider(format!("ttrpc connect failed {e}")))?;
         let client = AttestationAgentServiceClient::new(c);
         Ok(Self { client })
     }

--- a/attestation-agent/kbs_protocol/src/token_provider/aa/mod.rs
+++ b/attestation-agent/kbs_protocol/src/token_provider/aa/mod.rs
@@ -33,7 +33,11 @@ struct Message {
 
 impl AATokenProvider {
     pub async fn new() -> Result<Self> {
-        let c = ttrpc::r#async::Client::connect(AA_SOCKET_FILE)
+        Self::new_with_socket(AA_SOCKET_FILE).await
+    }
+
+    pub async fn new_with_socket(aa_socket: &str) -> Result<Self> {
+        let c = ttrpc::r#async::Client::connect(aa_socket)
             .map_err(|e| Error::AATokenProvider(format!("ttrpc connect failed {e:?}")))?;
         let client = AttestationAgentServiceClient::new(c);
         Ok(Self { client })

--- a/confidential-data-hub/hub/src/kms/plugins/kbs/offline_fs.rs
+++ b/confidential-data-hub/hub/src/kms/plugins/kbs/offline_fs.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use log::warn;
-use resource_uri::ResourceUri;
+use resource_uri::{ResourcePluginPath, ResourceUri};
 use tokio::fs;
 
 use super::Kbc;
@@ -26,7 +26,13 @@ pub struct OfflineFsKbc {
 #[async_trait]
 impl Kbc for OfflineFsKbc {
     async fn get_resource(&mut self, rid: ResourceUri) -> Result<Vec<u8>> {
-        let resource_path = rid.resource_path();
+        let ResourcePluginPath { repo, r#type, tag } =
+            ResourcePluginPath::try_from(&rid).map_err(|e| {
+                Error::KbsClientError(format!(
+                    "offline-fs-kbc only supports the resource plugin: {e:#}"
+                ))
+            })?;
+        let resource_path = format!("{repo}/{type}/{tag}");
         self.resources
             .get(&resource_path)
             .ok_or(Error::KbsClientError(format!(
@@ -99,5 +105,14 @@ mod tests {
             kbc.get_resource(rid).await.expect("get key failed")[..],
             *value
         );
+    }
+
+    #[tokio::test]
+    async fn rejects_non_resource_plugin() {
+        let mut kbc = OfflineFsKbc {
+            resources: Default::default(),
+        };
+        let rid = ResourceUri::try_from("kbs+pkcs11:///slot/key/label").unwrap();
+        assert!(kbc.get_resource(rid).await.is_err());
     }
 }

--- a/confidential-data-hub/hub/src/kms/plugins/kbs/sev/client.rs
+++ b/confidential-data-hub/hub/src/kms/plugins/kbs/sev/client.rs
@@ -13,7 +13,7 @@ use lazy_static::lazy_static;
 use protos::grpc::aa::keybroker::{
     key_broker_service_client::KeyBrokerServiceClient, OnlineSecretRequest, RequestDetails,
 };
-use resource_uri::ResourceUri;
+use resource_uri::{ResourcePluginPath, ResourceUri};
 use serde::Deserialize;
 use tokio::{fs, sync::RwLock};
 use tonic::transport::Uri;
@@ -166,7 +166,11 @@ impl Kbc for OnlineSevKbc {
     async fn get_resource(&mut self, rid: ResourceUri) -> Result<Vec<u8>> {
         let reader = ONLINE_SEV_KBC.read().await;
         let kbc = reader.as_ref().expect("Must be initialized");
-        match &rid.r#type[..] {
+        let ResourcePluginPath { r#type, .. } =
+            ResourcePluginPath::try_from(&rid).map_err(|e| {
+                Error::KbsClientError(format!("online-sev-kbc: parse resource URI failed: {e:?}"))
+            })?;
+        match r#type.as_str() {
             "client-id" => Ok(kbc.client_id.hyphenated().to_string().into_bytes()),
             _ => self.get_resource_from_kbs(rid, "resource").await,
         }

--- a/confidential-data-hub/hub/src/storage/volume_type/blockdevice/mod.rs
+++ b/confidential-data-hub/hub/src/storage/volume_type/blockdevice/mod.rs
@@ -16,6 +16,7 @@ use strum::{Display, EnumString};
 use crate::kms;
 use crate::kms::{Annotations, ProviderSettings};
 use crate::secret;
+use resource_uri::ResourceUri;
 
 #[derive(EnumString, Serialize, Deserialize, Display, Debug, PartialEq, Eq)]
 pub enum BlockDeviceEncryptType {
@@ -59,7 +60,7 @@ async fn get_plaintext_key(resource: &str) -> anyhow::Result<Vec<u8>> {
         return Ok(unsealed);
     }
 
-    if resource.starts_with("kbs://") {
+    if ResourceUri::try_from(resource).is_ok() {
         let secret = kms::new_getter("kbs", ProviderSettings::default())
             .await?
             .get_secret(resource, &Annotations::default())

--- a/image-rs/src/resource/mod.rs
+++ b/image-rs/src/resource/mod.rs
@@ -24,6 +24,10 @@ pub struct ResourceProvider {
     secure_channel: kbs::SecureChannel,
 }
 
+fn is_kbs_scheme(scheme: &str) -> bool {
+    scheme == "kbs" || scheme.starts_with("kbs+")
+}
+
 impl ResourceProvider {
     pub fn new(_kbc_name: &str, _kbs_uri: &str, _work_dir: &Path) -> Result<Self> {
         #[cfg(feature = "kbs")]
@@ -48,7 +52,7 @@ impl ResourceProvider {
 
         let url = url::Url::parse(&uri).map_err(|e| anyhow!("Failed to parse: {:?}", e))?;
         match url.scheme() {
-            "kbs" => {
+            scheme if is_kbs_scheme(scheme) => {
                 #[cfg(feature = "kbs")]
                 {
                     self.secure_channel.get_resource(&uri).await
@@ -69,5 +73,21 @@ impl ResourceProvider {
             }
             others => bail!("not support scheme {}", others),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_kbs_scheme;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("kbs", true)]
+    #[case("kbs+pkcs11", true)]
+    #[case("kbs+nebula-ca", true)]
+    #[case("file", false)]
+    #[case("https", false)]
+    fn recognizes_kbs_plugin_schemes(#[case] scheme: &str, #[case] expected: bool) {
+        assert_eq!(is_kbs_scheme(scheme), expected);
     }
 }

--- a/protos/protos/attestation-agent/attestation-agent.proto
+++ b/protos/protos/attestation-agent/attestation-agent.proto
@@ -40,7 +40,15 @@ message ExtendRuntimeMeasurementRequest {
     optional uint64 RegisterIndex = 4;
 }
 
-message ExtendRuntimeMeasurementResponse {}
+enum RuntimeMeasurementResult {
+    OK = 0;
+    NOT_SUPPORTED = 1;
+    NOT_ENABLED = 2;
+}
+
+message ExtendRuntimeMeasurementResponse {
+    RuntimeMeasurementResult Result = 1;
+}
 
 message InitDataPlaintext {
     bytes Content = 1;

--- a/protos/src/grpc/aa/attestation_agent.rs
+++ b/protos/src/grpc/aa/attestation_agent.rs
@@ -45,7 +45,10 @@ pub struct ExtendRuntimeMeasurementRequest {
     pub register_index: ::core::option::Option<u64>,
 }
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
-pub struct ExtendRuntimeMeasurementResponse {}
+pub struct ExtendRuntimeMeasurementResponse {
+    #[prost(enumeration = "RuntimeMeasurementResult", tag = "1")]
+    pub result: i32,
+}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InitDataPlaintext {
     #[prost(bytes = "vec", tag = "1")]
@@ -73,6 +76,35 @@ pub struct GetAdditionalTeesRequest {}
 pub struct GetAdditionalTeesResponse {
     #[prost(string, repeated, tag = "1")]
     pub additional_tees: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum RuntimeMeasurementResult {
+    Ok = 0,
+    NotSupported = 1,
+    NotEnabled = 2,
+}
+impl RuntimeMeasurementResult {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            RuntimeMeasurementResult::Ok => "OK",
+            RuntimeMeasurementResult::NotSupported => "NOT_SUPPORTED",
+            RuntimeMeasurementResult::NotEnabled => "NOT_ENABLED",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "OK" => Some(Self::Ok),
+            "NOT_SUPPORTED" => Some(Self::NotSupported),
+            "NOT_ENABLED" => Some(Self::NotEnabled),
+            _ => None,
+        }
+    }
 }
 /// Generated client implementations.
 pub mod attestation_agent_service_client {

--- a/protos/src/ttrpc/aa/attestation_agent.rs
+++ b/protos/src/ttrpc/aa/attestation_agent.rs
@@ -831,6 +831,9 @@ impl ::protobuf::reflect::ProtobufValue for ExtendRuntimeMeasurementRequest {
 // @@protoc_insertion_point(message:attestation_agent.ExtendRuntimeMeasurementResponse)
 #[derive(PartialEq,Clone,Default,Debug)]
 pub struct ExtendRuntimeMeasurementResponse {
+    // message fields
+    // @@protoc_insertion_point(field:attestation_agent.ExtendRuntimeMeasurementResponse.Result)
+    pub Result: ::protobuf::EnumOrUnknown<RuntimeMeasurementResult>,
     // special fields
     // @@protoc_insertion_point(special_field:attestation_agent.ExtendRuntimeMeasurementResponse.special_fields)
     pub special_fields: ::protobuf::SpecialFields,
@@ -848,8 +851,13 @@ impl ExtendRuntimeMeasurementResponse {
     }
 
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(0);
+        let mut fields = ::std::vec::Vec::with_capacity(1);
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
+        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
+            "Result",
+            |m: &ExtendRuntimeMeasurementResponse| { &m.Result },
+            |m: &mut ExtendRuntimeMeasurementResponse| { &mut m.Result },
+        ));
         ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<ExtendRuntimeMeasurementResponse>(
             "ExtendRuntimeMeasurementResponse",
             fields,
@@ -868,6 +876,9 @@ impl ::protobuf::Message for ExtendRuntimeMeasurementResponse {
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
         while let Some(tag) = is.read_raw_tag_or_eof()? {
             match tag {
+                8 => {
+                    self.Result = is.read_enum_or_unknown()?;
+                },
                 tag => {
                     ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
                 },
@@ -880,12 +891,18 @@ impl ::protobuf::Message for ExtendRuntimeMeasurementResponse {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u64 {
         let mut my_size = 0;
+        if self.Result != ::protobuf::EnumOrUnknown::new(RuntimeMeasurementResult::OK) {
+            my_size += ::protobuf::rt::int32_size(1, self.Result.value());
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
         self.special_fields.cached_size().set(my_size as u32);
         my_size
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
+        if self.Result != ::protobuf::EnumOrUnknown::new(RuntimeMeasurementResult::OK) {
+            os.write_enum(1, ::protobuf::EnumOrUnknown::value(&self.Result))?;
+        }
         os.write_unknown_fields(self.special_fields.unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -903,11 +920,13 @@ impl ::protobuf::Message for ExtendRuntimeMeasurementResponse {
     }
 
     fn clear(&mut self) {
+        self.Result = ::protobuf::EnumOrUnknown::new(RuntimeMeasurementResult::OK);
         self.special_fields.clear();
     }
 
     fn default_instance() -> &'static ExtendRuntimeMeasurementResponse {
         static instance: ExtendRuntimeMeasurementResponse = ExtendRuntimeMeasurementResponse {
+            Result: ::protobuf::EnumOrUnknown::from_i32(0),
             special_fields: ::protobuf::SpecialFields::new(),
         };
         &instance
@@ -1746,6 +1765,73 @@ impl ::protobuf::reflect::ProtobufValue for GetAdditionalTeesResponse {
     type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
 }
 
+#[derive(Clone,Copy,PartialEq,Eq,Debug,Hash)]
+// @@protoc_insertion_point(enum:attestation_agent.RuntimeMeasurementResult)
+pub enum RuntimeMeasurementResult {
+    // @@protoc_insertion_point(enum_value:attestation_agent.RuntimeMeasurementResult.OK)
+    OK = 0,
+    // @@protoc_insertion_point(enum_value:attestation_agent.RuntimeMeasurementResult.NOT_SUPPORTED)
+    NOT_SUPPORTED = 1,
+    // @@protoc_insertion_point(enum_value:attestation_agent.RuntimeMeasurementResult.NOT_ENABLED)
+    NOT_ENABLED = 2,
+}
+
+impl ::protobuf::Enum for RuntimeMeasurementResult {
+    const NAME: &'static str = "RuntimeMeasurementResult";
+
+    fn value(&self) -> i32 {
+        *self as i32
+    }
+
+    fn from_i32(value: i32) -> ::std::option::Option<RuntimeMeasurementResult> {
+        match value {
+            0 => ::std::option::Option::Some(RuntimeMeasurementResult::OK),
+            1 => ::std::option::Option::Some(RuntimeMeasurementResult::NOT_SUPPORTED),
+            2 => ::std::option::Option::Some(RuntimeMeasurementResult::NOT_ENABLED),
+            _ => ::std::option::Option::None
+        }
+    }
+
+    fn from_str(str: &str) -> ::std::option::Option<RuntimeMeasurementResult> {
+        match str {
+            "OK" => ::std::option::Option::Some(RuntimeMeasurementResult::OK),
+            "NOT_SUPPORTED" => ::std::option::Option::Some(RuntimeMeasurementResult::NOT_SUPPORTED),
+            "NOT_ENABLED" => ::std::option::Option::Some(RuntimeMeasurementResult::NOT_ENABLED),
+            _ => ::std::option::Option::None
+        }
+    }
+
+    const VALUES: &'static [RuntimeMeasurementResult] = &[
+        RuntimeMeasurementResult::OK,
+        RuntimeMeasurementResult::NOT_SUPPORTED,
+        RuntimeMeasurementResult::NOT_ENABLED,
+    ];
+}
+
+impl ::protobuf::EnumFull for RuntimeMeasurementResult {
+    fn enum_descriptor() -> ::protobuf::reflect::EnumDescriptor {
+        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::rt::Lazy::new();
+        descriptor.get(|| file_descriptor().enum_by_package_relative_name("RuntimeMeasurementResult").unwrap()).clone()
+    }
+
+    fn descriptor(&self) -> ::protobuf::reflect::EnumValueDescriptor {
+        let index = *self as usize;
+        Self::enum_descriptor().value_by_index(index)
+    }
+}
+
+impl ::std::default::Default for RuntimeMeasurementResult {
+    fn default() -> Self {
+        RuntimeMeasurementResult::OK
+    }
+}
+
+impl RuntimeMeasurementResult {
+    fn generated_enum_descriptor_data() -> ::protobuf::reflect::GeneratedEnumDescriptorData {
+        ::protobuf::reflect::GeneratedEnumDescriptorData::new::<RuntimeMeasurementResult>("RuntimeMeasurementResult")
+    }
+}
+
 static file_descriptor_proto_data: &'static [u8] = b"\
     \n\x17attestation-agent.proto\x12\x11attestation_agent\"6\n\x12GetEviden\
     ceRequest\x12\x20\n\x0bRuntimeData\x18\x01\x20\x01(\x0cR\x0bRuntimeData\
@@ -1759,26 +1845,29 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x06Domain\x18\x01\x20\x01(\tR\x06Domain\x12\x1c\n\tOperation\x18\x02\
     \x20\x01(\tR\tOperation\x12\x18\n\x07Content\x18\x03\x20\x01(\tR\x07Cont\
     ent\x12)\n\rRegisterIndex\x18\x04\x20\x01(\x04H\0R\rRegisterIndex\x88\
-    \x01\x01B\x10\n\x0e_RegisterIndex\"\"\n\x20ExtendRuntimeMeasurementRespo\
-    nse\"K\n\x11InitDataPlaintext\x12\x18\n\x07Content\x18\x01\x20\x01(\x0cR\
-    \x07Content\x12\x1c\n\tAlgorithm\x18\x02\x20\x01(\tR\tAlgorithm\"-\n\x13\
-    BindInitDataRequest\x12\x16\n\x06Digest\x18\x01\x20\x01(\x0cR\x06Digest\
-    \"\x16\n\x14BindInitDataResponse\"\x13\n\x11GetTeeTypeRequest\"&\n\x12Ge\
-    tTeeTypeResponse\x12\x10\n\x03tee\x18\x01\x20\x01(\tR\x03tee\"\x1a\n\x18\
-    GetAdditionalTeesRequest\"D\n\x19GetAdditionalTeesResponse\x12'\n\x0fadd\
-    itional_tees\x18\x01\x20\x03(\tR\x0eadditionalTees2\xf0\x05\n\x17Attesta\
-    tionAgentService\x12\\\n\x0bGetEvidence\x12%.attestation_agent.GetEviden\
-    ceRequest\x1a&.attestation_agent.GetEvidenceResponse\x12p\n\x15GetAdditi\
-    onalEvidence\x12/.attestation_agent.GetAdditionalEvidenceRequest\x1a&.at\
-    testation_agent.GetEvidenceResponse\x12S\n\x08GetToken\x12\".attestation\
-    _agent.GetTokenRequest\x1a#.attestation_agent.GetTokenResponse\x12\x83\
-    \x01\n\x18ExtendRuntimeMeasurement\x122.attestation_agent.ExtendRuntimeM\
-    easurementRequest\x1a3.attestation_agent.ExtendRuntimeMeasurementRespons\
-    e\x12_\n\x0cBindInitData\x12&.attestation_agent.BindInitDataRequest\x1a'\
-    .attestation_agent.BindInitDataResponse\x12Y\n\nGetTeeType\x12$.attestat\
-    ion_agent.GetTeeTypeRequest\x1a%.attestation_agent.GetTeeTypeResponse\
-    \x12n\n\x11GetAdditionalTees\x12+.attestation_agent.GetAdditionalTeesReq\
-    uest\x1a,.attestation_agent.GetAdditionalTeesResponseb\x06proto3\
+    \x01\x01B\x10\n\x0e_RegisterIndex\"g\n\x20ExtendRuntimeMeasurementRespon\
+    se\x12C\n\x06Result\x18\x01\x20\x01(\x0e2+.attestation_agent.RuntimeMeas\
+    urementResultR\x06Result\"K\n\x11InitDataPlaintext\x12\x18\n\x07Content\
+    \x18\x01\x20\x01(\x0cR\x07Content\x12\x1c\n\tAlgorithm\x18\x02\x20\x01(\
+    \tR\tAlgorithm\"-\n\x13BindInitDataRequest\x12\x16\n\x06Digest\x18\x01\
+    \x20\x01(\x0cR\x06Digest\"\x16\n\x14BindInitDataResponse\"\x13\n\x11GetT\
+    eeTypeRequest\"&\n\x12GetTeeTypeResponse\x12\x10\n\x03tee\x18\x01\x20\
+    \x01(\tR\x03tee\"\x1a\n\x18GetAdditionalTeesRequest\"D\n\x19GetAdditiona\
+    lTeesResponse\x12'\n\x0fadditional_tees\x18\x01\x20\x03(\tR\x0eadditiona\
+    lTees*F\n\x18RuntimeMeasurementResult\x12\x06\n\x02OK\x10\0\x12\x11\n\rN\
+    OT_SUPPORTED\x10\x01\x12\x0f\n\x0bNOT_ENABLED\x10\x022\xf0\x05\n\x17Atte\
+    stationAgentService\x12\\\n\x0bGetEvidence\x12%.attestation_agent.GetEvi\
+    denceRequest\x1a&.attestation_agent.GetEvidenceResponse\x12p\n\x15GetAdd\
+    itionalEvidence\x12/.attestation_agent.GetAdditionalEvidenceRequest\x1a&\
+    .attestation_agent.GetEvidenceResponse\x12S\n\x08GetToken\x12\".attestat\
+    ion_agent.GetTokenRequest\x1a#.attestation_agent.GetTokenResponse\x12\
+    \x83\x01\n\x18ExtendRuntimeMeasurement\x122.attestation_agent.ExtendRunt\
+    imeMeasurementRequest\x1a3.attestation_agent.ExtendRuntimeMeasurementRes\
+    ponse\x12_\n\x0cBindInitData\x12&.attestation_agent.BindInitDataRequest\
+    \x1a'.attestation_agent.BindInitDataResponse\x12Y\n\nGetTeeType\x12$.att\
+    estation_agent.GetTeeTypeRequest\x1a%.attestation_agent.GetTeeTypeRespon\
+    se\x12n\n\x11GetAdditionalTees\x12+.attestation_agent.GetAdditionalTeesR\
+    equest\x1a,.attestation_agent.GetAdditionalTeesResponseb\x06proto3\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file
@@ -1811,7 +1900,8 @@ pub fn file_descriptor() -> &'static ::protobuf::reflect::FileDescriptor {
             messages.push(GetTeeTypeResponse::generated_message_descriptor_data());
             messages.push(GetAdditionalTeesRequest::generated_message_descriptor_data());
             messages.push(GetAdditionalTeesResponse::generated_message_descriptor_data());
-            let mut enums = ::std::vec::Vec::with_capacity(0);
+            let mut enums = ::std::vec::Vec::with_capacity(1);
+            enums.push(RuntimeMeasurementResult::generated_enum_descriptor_data());
             ::protobuf::reflect::GeneratedFileDescriptor::new_generated(
                 file_descriptor_proto(),
                 deps,


### PR DESCRIPTION
## Summary

This is the foundation PR for synchronizing upstream CDH/AA capabilities into the Inclavare fork.

- support canonical `kbs://` resource URIs and `kbs+<plugin>://` plugin URIs, including arbitrary positive path depth and query parameters;
- route plugin requests through the OpenAnolis Trustee `/kbs/v0/<plugin>/<path>` API while retaining the legacy three-segment adapter used by KBC implementations;
- handle explicit non-JSON plugin responses as raw bytes while keeping JSON/missing-content-type resource responses on the authenticated encrypted KBS path;
- report runtime-measurement outcomes as `OK`, `NOT_SUPPORTED`, or `NOT_ENABLED` across the AA library, gRPC, ttrpc, CLI, and REST API;
- advertise and implement runtime measurement support consistently for CSV, Hygon TPM, sample, system, Azure SNP/TDX vTPM, and TDX dynamic measurement backends.

## OpenAnolis Trustee compatibility

This PR intentionally remains integrated with `openanolis/trustee`; it does not switch to the Confidential Containers Trustee implementation.

- preserves the downstream `TRUSTEE_API_KEY` bearer header;
- preserves the OpenAnolis `Attestation` token header;
- retains the existing OpenAnolis Trustee/eventlog dependency and KBS routes;
- retains downstream online-SEV behavior and explicitly rejects unsupported plugin/path shapes in legacy KBCs instead of silently misrouting them.

AWS KMS/Secrets Manager is not included. Existing `CDH_CONFIG_PATH`, `mount_path`, and full GetResource error-chain behavior are untouched by this foundation PR.

## Commits

1. `feat: support Trustee resource plugin URIs`
2. `feat: report AA runtime measurement capability`
3. `fix: handle plaintext Trustee plugin responses`

## Validation

Unit and component tests:

- `cargo test -p resource_uri` — 11 passed
- `cargo test -p coco_keyprovider` — 9 passed
- `cargo test -p kbc --no-default-features --features sample_kbc,offline_fs_kbc,rust-crypto` — 10 passed
- `cargo test -p confidential-data-hub --lib` — 32 passed, 4 hardware/external tests ignored
- `cargo test -p api-server-rest` — 16 passed
- `cargo test -p image-rs resource::tests` — 5 passed
- `cargo test -p attester` — 35 passed, 7 hardware tests ignored; doctest passed
- complete AA test binary under an isolated root mount namespace — 30 passed, 3 external tests ignored
- KBS protocol suite, including Docker KBS encrypted-resource retrieval and local raw-plugin integration — 29 passed

Build and lint:

- `cargo fmt --all -- --check`
- AA `make lint`
- CDH Clippy with `-D warnings`
- image-rs default-feature Clippy with `-D warnings`
- trustee-attester all-attesters build and Clippy
- AA ttrpc/eventlog/TDX binary build with Rust 1.76-compatible dependency set

Real TDX end-to-end validation against the installed OpenAnolis Trustee stack:

- fetched `kbs+tpm-pca:///certificate` through the new client using RCAR attestation plus `TRUSTEE_API_KEY`; the returned raw certificate matched the direct OpenAnolis KBS plugin response;
- extended PCR 16 and verified that only TDX RTMR3 changed, while RTMR0–2 remained unchanged;
- used the same runtime-data before and after extension and verified it remained bound in both TDX quotes;
- verified the new event in both the on-disk AA eventlog and the CC eventlog embedded in evidence;
- disabled event logging in a temporary AA configuration and verified the explicit `NOT_ENABLED` response and no RTMR change;
- restored and rechecked the installed AA, CDH, REST API, KBS, and Trustee Gateway services after testing.
