### PR TITLE
feat(cdh): align KBC lifecycle and configuration with upstream

### DIFF
--- a/confidential-data-hub/docs/RESOURCES_SERVICES.md
+++ b/confidential-data-hub/docs/RESOURCES_SERVICES.md
@@ -59,6 +59,12 @@ By historical and backward-compatilibity reasons, `offline_fs_kbc` reads key/val
 **/etc/aa-offline_fs_kbc-keys.json** and **/etc/aa-offline_fs_kbc-resources.json** files. Here we
 will use **/etc/aa-offline_fs_kbc-resources.json** solely.
 
+Additional resource files can be supplied through the comma-separated
+`OFFLINE_FS_KBC_EXTRA_FILE_PATH` environment variable. They are loaded after
+the two standard files, in the listed order, so a later file overrides an
+earlier definition of the same resource. Whitespace and empty list entries are
+ignored.
+
 First, build the CDH. To faster the build, disable all KMS providers and let enabled only the
 KBS resources provider:
 

--- a/confidential-data-hub/example.config.json
+++ b/confidential-data-hub/example.config.json
@@ -1,5 +1,8 @@
 {
     "socket": "unix:///run/confidential-containers/cdh.sock",
+    "aa": {
+        "aa_socket": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+    },
     "kbc": {
         "name": "cc_kbc",
         "url": "http://example.io:8080",

--- a/confidential-data-hub/example.config.json
+++ b/confidential-data-hub/example.config.json
@@ -3,6 +3,9 @@
     "aa": {
         "aa_socket": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
     },
+    "log": {
+        "level": "info"
+    },
     "kbc": {
         "name": "cc_kbc",
         "url": "http://example.io:8080",

--- a/confidential-data-hub/example.config.toml
+++ b/confidential-data-hub/example.config.toml
@@ -6,6 +6,10 @@ socket = "unix:///run/confidential-containers/cdh.sock"
 [aa]
 aa_socket = "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
 
+# Used when RUST_LOG is not set.
+[log]
+level = "info"
+
 # KBC related configs.
 [kbc]
 # Required. The KBC name. It could be `cc_kbc`, `online_sev_kbc` or

--- a/confidential-data-hub/example.config.toml
+++ b/confidential-data-hub/example.config.toml
@@ -1,6 +1,11 @@
 # The ttrpc sock of CDH that is used to listen to the requests
 socket = "unix:///run/confidential-containers/cdh.sock"
 
+# The ttrpc socket CDH uses to obtain a passport token from AA.
+# The legacy top-level `aa_socket` setting is also accepted.
+[aa]
+aa_socket = "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+
 # KBC related configs.
 [kbc]
 # Required. The KBC name. It could be `cc_kbc`, `online_sev_kbc` or

--- a/confidential-data-hub/hub/Cargo.toml
+++ b/confidential-data-hub/hub/Cargo.toml
@@ -53,7 +53,7 @@ image-rs = { path = "../../image-rs", default-features = false, features = [
     "kata-cc-rustls-tls",
 ] }
 kbs_protocol = { path = "../../attestation-agent/kbs_protocol", default-features = false, features = [
-    "background_check",
+    "passport",
     "aa_ttrpc",
     "openssl",
 ], optional = true }

--- a/confidential-data-hub/hub/src/bin/cdh-oneshot.rs
+++ b/confidential-data-hub/hub/src/bin/cdh-oneshot.rs
@@ -94,9 +94,9 @@ struct PullImageArgs {
 
 #[tokio::main]
 async fn main() {
-    env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
     let args = Cli::parse();
     let config = CdhConfig::new(args.config).expect("failed to initialize cdh config");
+    env_logger::init_from_env(env_logger::Env::new().default_filter_or(&config.log.level));
     config.set_configuration_envs();
 
     let cdh = Hub::new(config).await.expect("failed to start CDH");

--- a/confidential-data-hub/hub/src/bin/grpc-cdh.rs
+++ b/confidential-data-hub/hub/src/bin/grpc-cdh.rs
@@ -28,10 +28,10 @@ struct Cli {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
     let cli = Cli::parse();
 
     let config = CdhConfig::new(cli.config)?;
+    env_logger::init_from_env(env_logger::Env::new().default_filter_or(&config.log.level));
 
     let cdh_socket = config.socket.parse::<SocketAddr>()?;
 

--- a/confidential-data-hub/hub/src/bin/ttrpc-cdh.rs
+++ b/confidential-data-hub/hub/src/bin/ttrpc-cdh.rs
@@ -43,10 +43,10 @@ struct Cli {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
     let cli = Cli::parse();
 
     let config = CdhConfig::new(cli.config)?;
+    env_logger::init_from_env(env_logger::Env::new().default_filter_or(&config.log.level));
 
     let unix_socket_path = config
         .socket

--- a/confidential-data-hub/hub/src/config.rs
+++ b/confidential-data-hub/hub/src/config.rs
@@ -15,12 +15,13 @@ use serde::Deserialize;
 cfg_if::cfg_if! {
     if #[cfg(feature = "ttrpc")] {
         const DEFAULT_CDH_SOCKET_ADDR: &str = "unix:///run/confidential-containers/cdh.sock";
-        const DEFAULT_AA_SOCKET_ADDR: &str = "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock";
     } else {
         const DEFAULT_CDH_SOCKET_ADDR: &str = "127.0.0.1:50000";
-        const DEFAULT_AA_SOCKET_ADDR: &str = "127.0.0.1:50004";
     }
 }
+
+const DEFAULT_AA_SOCKET_ADDR: &str =
+    "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock";
 
 const CDH_DEFAULT_IMAGE_AUTHENTICATED_REGISTRY_CREDENTIALS: &str =
     "CDH_DEFAULT_IMAGE_AUTHENTICATED_REGISTRY_CREDENTIALS";
@@ -53,7 +54,31 @@ pub struct Credential {
     pub path: String,
 }
 
+fn default_aa_socket_addr() -> String {
+    DEFAULT_AA_SOCKET_ADDR.to_string()
+}
+
+/// Connection settings for the Attestation Agent.
+///
+/// CDH uses the AA ttrpc API to obtain a Trustee passport token.  The nested
+/// `[aa]` form matches upstream configuration, while the legacy top-level
+/// `aa_socket` field remains accepted by [`RawCdhConfig`].
 #[derive(Clone, Deserialize, Debug, PartialEq)]
+pub struct AaConfig {
+    #[serde(default = "default_aa_socket_addr")]
+    pub aa_socket: String,
+}
+
+impl Default for AaConfig {
+    fn default() -> Self {
+        Self {
+            aa_socket: default_aa_socket_addr(),
+        }
+    }
+}
+
+#[derive(Clone, Deserialize, Debug, PartialEq)]
+#[serde(from = "RawCdhConfig")]
 pub struct CdhConfig {
     pub kbc: KbsConfig,
 
@@ -69,6 +94,51 @@ pub struct CdhConfig {
     pub socket: String,
 
     pub aa_socket: String,
+}
+
+#[derive(Deserialize)]
+struct RawCdhConfig {
+    kbc: KbsConfig,
+
+    #[serde(default)]
+    credentials: Vec<Credential>,
+
+    #[serde(default = "ImageConfig::from_kernel_cmdline")]
+    image: ImageConfig,
+
+    #[serde(default)]
+    socket: Option<String>,
+
+    /// Upstream configuration form.
+    #[serde(default)]
+    aa: Option<AaConfig>,
+
+    /// Legacy Inclavare configuration form.
+    #[serde(default)]
+    aa_socket: Option<String>,
+}
+
+impl From<RawCdhConfig> for CdhConfig {
+    fn from(raw: RawCdhConfig) -> Self {
+        // Prefer the upstream nested form when both forms are explicitly
+        // present.  Otherwise retain the legacy top-level value and finally
+        // fall back to the standard AA ttrpc socket.
+        let aa_socket = raw
+            .aa
+            .map(|aa| aa.aa_socket)
+            .or(raw.aa_socket)
+            .unwrap_or_else(default_aa_socket_addr);
+
+        Self {
+            kbc: raw.kbc,
+            credentials: raw.credentials,
+            image: raw.image,
+            socket: raw
+                .socket
+                .unwrap_or_else(|| DEFAULT_CDH_SOCKET_ADDR.to_string()),
+            aa_socket,
+        }
+    }
 }
 
 impl CdhConfig {
@@ -117,8 +187,6 @@ impl CdhConfig {
     /// `config` crate.
     fn from_file(config_path: &str) -> Result<Self> {
         let c = Config::builder()
-            .set_default("socket", DEFAULT_CDH_SOCKET_ADDR)?
-            .set_default("aa_socket", DEFAULT_AA_SOCKET_ADDR)?
             .set_default("kbc.url", "")?
             .add_source(File::with_name(config_path))
             .build()?;
@@ -170,6 +238,9 @@ impl CdhConfig {
                 "AA_KBC_PARAMS",
                 format!("{}::{}", self.kbc.name, self.kbc.url),
             );
+        }
+        if env::var("AA_SOCKET").is_err() {
+            env::set_var("AA_SOCKET", &self.aa_socket);
         }
         // KBS configurations
         if let Some(kbs_cert) = &self.kbc.kbs_cert {
@@ -305,6 +376,111 @@ some_undefined_field = "unknown value"
         match expected {
             Some(cfg) => assert_eq!(cfg, res.unwrap()),
             None => assert!(res.is_err()),
+        }
+    }
+
+    #[rstest]
+    #[case(
+        r#"
+[kbc]
+name = "offline_fs_kbc"
+
+[aa]
+aa_socket = "unix:///run/custom/upstream-aa.sock"
+"#,
+        "unix:///run/custom/upstream-aa.sock"
+    )]
+    #[case(
+        r#"
+aa_socket = "unix:///run/custom/legacy-aa.sock"
+
+[kbc]
+name = "offline_fs_kbc"
+"#,
+        "unix:///run/custom/legacy-aa.sock"
+    )]
+    #[case(
+        r#"
+aa_socket = "unix:///run/custom/legacy-aa.sock"
+
+[kbc]
+name = "offline_fs_kbc"
+
+[aa]
+aa_socket = "unix:///run/custom/upstream-aa.sock"
+"#,
+        "unix:///run/custom/upstream-aa.sock"
+    )]
+    #[case(
+        r#"
+[kbc]
+name = "offline_fs_kbc"
+
+[aa]
+"#,
+        DEFAULT_AA_SOCKET_ADDR
+    )]
+    fn aa_socket_config_compatibility(#[case] config: &str, #[case] expected: &str) {
+        let mut file = tempfile::Builder::new()
+            .append(true)
+            .suffix(".toml")
+            .tempfile()
+            .unwrap();
+        file.write_all(config.as_bytes()).unwrap();
+
+        let config = CdhConfig::from_file(file.path().to_str().unwrap()).unwrap();
+        assert_eq!(config.aa_socket, expected);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn set_configuration_envs_sets_defaults_without_overriding_deployment_values() {
+        let old_kbc_params = env::var_os("AA_KBC_PARAMS");
+        let old_aa_socket = env::var_os("AA_SOCKET");
+        env::remove_var("AA_KBC_PARAMS");
+        env::remove_var("AA_SOCKET");
+
+        let config = CdhConfig {
+            kbc: KbsConfig {
+                name: "cc_kbc".into(),
+                url: "http://127.0.0.1:8080".into(),
+                kbs_cert: None,
+            },
+            credentials: Vec::new(),
+            image: ImageConfig::default(),
+            socket: DEFAULT_CDH_SOCKET_ADDR.into(),
+            aa_socket: "unix:///run/custom/config-aa.sock".into(),
+        };
+
+        config.set_configuration_envs();
+        assert_eq!(
+            env::var("AA_KBC_PARAMS").unwrap(),
+            "cc_kbc::http://127.0.0.1:8080"
+        );
+        assert_eq!(
+            env::var("AA_SOCKET").unwrap(),
+            "unix:///run/custom/config-aa.sock"
+        );
+
+        env::set_var("AA_KBC_PARAMS", "deployment_kbc::http://kbs.example");
+        env::set_var("AA_SOCKET", "unix:///run/custom/deployment-aa.sock");
+        config.set_configuration_envs();
+        assert_eq!(
+            env::var("AA_KBC_PARAMS").unwrap(),
+            "deployment_kbc::http://kbs.example"
+        );
+        assert_eq!(
+            env::var("AA_SOCKET").unwrap(),
+            "unix:///run/custom/deployment-aa.sock"
+        );
+
+        match old_kbc_params {
+            Some(value) => env::set_var("AA_KBC_PARAMS", value),
+            None => env::remove_var("AA_KBC_PARAMS"),
+        }
+        match old_aa_socket {
+            Some(value) => env::set_var("AA_SOCKET", value),
+            None => env::remove_var("AA_SOCKET"),
         }
     }
 

--- a/confidential-data-hub/hub/src/config.rs
+++ b/confidential-data-hub/hub/src/config.rs
@@ -22,6 +22,7 @@ cfg_if::cfg_if! {
 
 const DEFAULT_AA_SOCKET_ADDR: &str =
     "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock";
+const DEFAULT_LOG_LEVEL: &str = "info";
 
 const CDH_DEFAULT_IMAGE_AUTHENTICATED_REGISTRY_CREDENTIALS: &str =
     "CDH_DEFAULT_IMAGE_AUTHENTICATED_REGISTRY_CREDENTIALS";
@@ -77,6 +78,24 @@ impl Default for AaConfig {
     }
 }
 
+fn default_log_level() -> String {
+    DEFAULT_LOG_LEVEL.to_string()
+}
+
+#[derive(Clone, Deserialize, Debug, PartialEq)]
+pub struct LogConfig {
+    #[serde(default = "default_log_level")]
+    pub level: String,
+}
+
+impl Default for LogConfig {
+    fn default() -> Self {
+        Self {
+            level: default_log_level(),
+        }
+    }
+}
+
 #[derive(Clone, Deserialize, Debug, PartialEq)]
 #[serde(from = "RawCdhConfig")]
 pub struct CdhConfig {
@@ -94,6 +113,8 @@ pub struct CdhConfig {
     pub socket: String,
 
     pub aa_socket: String,
+
+    pub log: LogConfig,
 }
 
 #[derive(Deserialize)]
@@ -116,6 +137,9 @@ struct RawCdhConfig {
     /// Legacy Inclavare configuration form.
     #[serde(default)]
     aa_socket: Option<String>,
+
+    #[serde(default)]
+    log: LogConfig,
 }
 
 impl From<RawCdhConfig> for CdhConfig {
@@ -137,6 +161,7 @@ impl From<RawCdhConfig> for CdhConfig {
                 .socket
                 .unwrap_or_else(|| DEFAULT_CDH_SOCKET_ADDR.to_string()),
             aa_socket,
+            log: raw.log,
         }
     }
 }
@@ -168,6 +193,7 @@ impl CdhConfig {
                     socket: DEFAULT_CDH_SOCKET_ADDR.into(),
                     aa_socket: DEFAULT_AA_SOCKET_ADDR.into(),
                     image: ImageConfig::from_kernel_cmdline(),
+                    log: LogConfig::default(),
                 }
             }
         };
@@ -259,13 +285,16 @@ mod tests {
 
     use crate::{
         config::{DEFAULT_AA_SOCKET_ADDR, DEFAULT_CDH_SOCKET_ADDR},
-        CdhConfig, KbsConfig,
+        CdhConfig, KbsConfig, LogConfig,
     };
 
     #[rstest]
     #[case(
         r#"
 socket = "unix:///run/confidential-containers/cdh.sock"
+
+[log]
+level = "debug"
 
 [kbc]
 name = "offline_fs_kbc"
@@ -299,6 +328,9 @@ image_pull_proxy = "http://127.0.0.1:8080"
             },
             socket: "unix:///run/confidential-containers/cdh.sock".to_string(),
             aa_socket: DEFAULT_AA_SOCKET_ADDR.to_string(),
+            log: LogConfig {
+                level: "debug".to_string(),
+            },
         })
     )]
     #[case(
@@ -336,6 +368,7 @@ name = "offline_fs_kbc"
         },
         socket: DEFAULT_CDH_SOCKET_ADDR.to_string(),
         aa_socket: DEFAULT_AA_SOCKET_ADDR.to_string(),
+        log: LogConfig::default(),
     })
     )]
     #[case(
@@ -363,6 +396,7 @@ some_undefined_field = "unknown value"
         },
         socket: DEFAULT_CDH_SOCKET_ADDR.to_string(),
         aa_socket: DEFAULT_AA_SOCKET_ADDR.to_string(),
+        log: LogConfig::default(),
     })
     )]
     fn read_config(#[case] config: &str, #[case] expected: Option<CdhConfig>) {
@@ -450,6 +484,7 @@ name = "offline_fs_kbc"
             image: ImageConfig::default(),
             socket: DEFAULT_CDH_SOCKET_ADDR.into(),
             aa_socket: "unix:///run/custom/config-aa.sock".into(),
+            log: LogConfig::default(),
         };
 
         config.set_configuration_envs();
@@ -501,6 +536,7 @@ name = "offline_fs_kbc"
             socket: DEFAULT_CDH_SOCKET_ADDR.into(),
             aa_socket: DEFAULT_AA_SOCKET_ADDR.into(),
             image: ImageConfig::from_kernel_cmdline(),
+            log: LogConfig::default(),
         };
         assert_eq!(config, expected);
 

--- a/confidential-data-hub/hub/src/kms/plugins/kbs/cc_kbc.rs
+++ b/confidential-data-hub/hub/src/kms/plugins/kbs/cc_kbc.rs
@@ -8,7 +8,7 @@ use std::env;
 use async_trait::async_trait;
 use kbs_protocol::{
     client::KbsClient as KbsProtocolClient,
-    evidence_provider::{AAEvidenceProvider, EvidenceProvider},
+    token_provider::{AATokenProvider, TokenProvider},
     KbsClientCapabilities, ResourceUri,
 };
 use log::{info, warn};
@@ -18,16 +18,18 @@ use super::{Error, Result};
 use super::Kbc;
 
 pub struct CcKbc {
-    client: KbsProtocolClient<Box<dyn EvidenceProvider>>,
+    client: KbsProtocolClient<Box<dyn TokenProvider>>,
 }
 
 impl CcKbc {
-    pub async fn new(kbs_host_url: &str) -> Result<Self> {
-        let evidence_provider = AAEvidenceProvider::new().await.map_err(|e| {
-            Error::KbsClientError(format!("create AA evidence provider failed: {e:?}"))
-        })?;
-        let client = kbs_protocol::KbsClientBuilder::with_evidence_provider(
-            Box::new(evidence_provider),
+    pub async fn new(kbs_host_url: &str, aa_socket: &str) -> Result<Self> {
+        let token_provider = AATokenProvider::new_with_socket(aa_socket)
+            .await
+            .map_err(|e| {
+                Error::KbsClientError(format!("create AA token provider failed: {e:?}"))
+            })?;
+        let client = kbs_protocol::KbsClientBuilder::with_token_provider(
+            Box::new(token_provider),
             kbs_host_url,
         );
 

--- a/confidential-data-hub/hub/src/kms/plugins/kbs/mod.rs
+++ b/confidential-data-hub/hub/src/kms/plugins/kbs/mod.rs
@@ -17,9 +17,10 @@ use std::{env, sync::Arc};
 
 use async_trait::async_trait;
 use attestation_agent::config::aa_kbc_params::AaKbcParams;
-use lazy_static::lazy_static;
 pub use resource_uri::ResourceUri;
 use tokio::sync::Mutex;
+#[cfg(feature = "sev")]
+use tokio::sync::OnceCell;
 
 use crate::kms::{Annotations, Error, Getter, Result};
 
@@ -31,64 +32,36 @@ enum RealClient {
     OfflineFs(offline_fs::OfflineFsKbc),
 }
 
-impl RealClient {
-    async fn new() -> Result<Self> {
-        let params = env::var("AA_KBC_PARAMS").expect("must be initialized");
-        let params = AaKbcParams::try_from(params)
-            .map_err(|e| Error::KbsClientError(format!("Failed to parse aa_kbc_params: {e:?}")))?;
-
-        let c = match &params.kbc[..] {
-            #[cfg(feature = "kbs")]
-            "cc_kbc" => {
-                let aa_socket = env::var("AA_SOCKET").map_err(|e| {
-                    Error::KbsClientError(format!("failed to read AA_SOCKET: {e}"))
-                })?;
-                RealClient::Cc(cc_kbc::CcKbc::new(&params.uri, &aa_socket).await?)
-            }
-            #[cfg(feature = "sev")]
-            "online_sev_kbc" => RealClient::Sev(sev::OnlineSevKbc::new(&params.uri).await?),
-            "offline_fs_kbc" => RealClient::OfflineFs(offline_fs::OfflineFsKbc::new().await?),
-            others => return Err(Error::KbsClientError(format!("unknown kbc name {others}, only support `cc_kbc`(feature `kbs`), `online_sev_kbc` (feature `sev`) and `offline_fs_kbc`."))),
-        };
-
-        Ok(c)
-    }
-}
-
-lazy_static! {
-    static ref KBS_CLIENT: Arc<Mutex<Option<RealClient>>> = Arc::new(Mutex::new(None));
-}
-
 #[async_trait]
 pub trait Kbc: Send + Sync {
     async fn get_resource(&mut self, _rid: ResourceUri) -> Result<Vec<u8>>;
 }
 
-/// A fake KbcClient to carry the [`Getter`] semantics. The real `new()`
-/// and `get_resource()` will happen to the static variable [`KBS_CLIENT`].
+/// The online-SEV KBC consumes one-shot guest state while it initializes, so
+/// that downstream-only provider must remain a process-wide singleton.  The
+/// URI is retained with the client to prevent a later configuration from
+/// silently reusing a singleton connected to a different KBS.
+#[cfg(feature = "sev")]
+static ONLINE_SEV_KBC: OnceCell<(String, Arc<Mutex<RealClient>>)> = OnceCell::const_new();
+
+/// A KBC-backed [`Getter`].
 ///
-/// Why we use a static variable here is the initialization of kbc is not
-/// idempotent. For example online-sev-kbc will delete a file on local
-/// filesystem, so we should try to reuse the online-sev-kbc created at the
-/// first time.
-pub struct KbcClient;
+/// The upstream cc-KBC and offline-fs-KBC implementations are independently
+/// initialized for each client.  This makes construction idempotent and avoids
+/// leaking the first CDH configuration into later clients.  Online-SEV keeps
+/// its original one-time initialization behavior.
+pub struct KbcClient {
+    client: Arc<Mutex<RealClient>>,
+}
 
 #[async_trait]
 impl Getter for KbcClient {
     async fn get_secret(&self, name: &str, _annotations: &Annotations) -> Result<Vec<u8>> {
         let resource_uri = ResourceUri::try_from(name)
             .map_err(|_| Error::KbsClientError(format!("illegal kbs resource uri: {name}")))?;
-        let real_client = KBS_CLIENT.clone();
-        let mut client = real_client.lock().await;
+        let mut client = self.client.lock().await;
 
-        if client.is_none() {
-            let c = RealClient::new().await?;
-            *client = Some(c);
-        }
-
-        let client = client.as_mut().expect("must be initialized");
-
-        match client {
+        match &mut *client {
             #[cfg(feature = "kbs")]
             RealClient::Cc(c) => c.get_resource(resource_uri).await,
             #[cfg(feature = "sev")]
@@ -100,13 +73,139 @@ impl Getter for KbcClient {
 
 impl KbcClient {
     pub async fn new() -> Result<Self> {
-        let client = KBS_CLIENT.clone();
-        let mut client = client.lock().await;
-        if client.is_none() {
-            let c = RealClient::new().await?;
-            *client = Some(c);
-        }
+        let params = env::var("AA_KBC_PARAMS")
+            .map_err(|e| Error::KbsClientError(format!("failed to read AA_KBC_PARAMS: {e}")))?;
+        let params = AaKbcParams::try_from(params)
+            .map_err(|e| Error::KbsClientError(format!("Failed to parse aa_kbc_params: {e:?}")))?;
 
-        Ok(KbcClient {})
+        let client = match &params.kbc[..] {
+            #[cfg(feature = "kbs")]
+            "cc_kbc" => {
+                let aa_socket = env::var("AA_SOCKET").map_err(|e| {
+                    Error::KbsClientError(format!("failed to read AA_SOCKET: {e}"))
+                })?;
+                Arc::new(Mutex::new(RealClient::Cc(
+                    cc_kbc::CcKbc::new(&params.uri, &aa_socket).await?,
+                )))
+            }
+            #[cfg(feature = "sev")]
+            "online_sev_kbc" => {
+                let (initialized_uri, client) = ONLINE_SEV_KBC
+                    .get_or_try_init(|| async {
+                        let client = sev::OnlineSevKbc::new(&params.uri).await?;
+                        Ok::<_, Error>((
+                            params.uri.clone(),
+                            Arc::new(Mutex::new(RealClient::Sev(client))),
+                        ))
+                    })
+                    .await?;
+                if initialized_uri != &params.uri {
+                    return Err(Error::KbsClientError(format!(
+                        "online-sev-kbc is already initialized for {initialized_uri}; refusing to reuse it for {}",
+                        params.uri
+                    )));
+                }
+                client.clone()
+            }
+            "offline_fs_kbc" => Arc::new(Mutex::new(RealClient::OfflineFs(
+                offline_fs::OfflineFsKbc::new().await?,
+            ))),
+            others => {
+                return Err(Error::KbsClientError(format!(
+                    "unknown kbc name {others}, only support `cc_kbc`(feature `kbs`), `online_sev_kbc` (feature `sev`) and `offline_fs_kbc`."
+                )))
+            }
+        };
+
+        Ok(Self { client })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{env, ffi::OsString, sync::Arc};
+
+    use serial_test::serial;
+
+    use super::KbcClient;
+
+    struct EnvRestore {
+        kbc_params: Option<OsString>,
+        aa_socket: Option<OsString>,
+    }
+
+    impl EnvRestore {
+        fn capture() -> Self {
+            Self {
+                kbc_params: env::var_os("AA_KBC_PARAMS"),
+                aa_socket: env::var_os("AA_SOCKET"),
+            }
+        }
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            match self.kbc_params.take() {
+                Some(value) => env::set_var("AA_KBC_PARAMS", value),
+                None => env::remove_var("AA_KBC_PARAMS"),
+            }
+            match self.aa_socket.take() {
+                Some(value) => env::set_var("AA_SOCKET", value),
+                None => env::remove_var("AA_SOCKET"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn offline_fs_does_not_require_aa_socket() {
+        let _restore = EnvRestore::capture();
+        env::set_var("AA_KBC_PARAMS", "offline_fs_kbc::");
+        env::remove_var("AA_SOCKET");
+
+        KbcClient::new()
+            .await
+            .expect("offline-fs-kbc must not require AA_SOCKET");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn idempotent_kbcs_are_initialized_per_client() {
+        let _restore = EnvRestore::capture();
+        env::set_var("AA_KBC_PARAMS", "offline_fs_kbc::");
+        env::remove_var("AA_SOCKET");
+
+        let first = KbcClient::new().await.unwrap();
+        let second = KbcClient::new().await.unwrap();
+        assert!(!Arc::ptr_eq(&first.client, &second.client));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn missing_kbc_configuration_returns_error() {
+        let _restore = EnvRestore::capture();
+        env::remove_var("AA_KBC_PARAMS");
+        env::remove_var("AA_SOCKET");
+
+        let error = KbcClient::new()
+            .await
+            .err()
+            .expect("must reject missing KBC");
+        assert!(error.to_string().contains("AA_KBC_PARAMS"));
+    }
+
+    #[cfg(feature = "kbs")]
+    #[tokio::test]
+    #[serial]
+    async fn cc_kbc_requires_aa_socket() {
+        let _restore = EnvRestore::capture();
+        env::set_var("AA_KBC_PARAMS", "cc_kbc::http://127.0.0.1:8080");
+        env::remove_var("AA_SOCKET");
+
+        let error = KbcClient::new()
+            .await
+            .err()
+            .expect("cc-kbc must require AA_SOCKET");
+        assert!(error.to_string().contains("AA_SOCKET"));
     }
 }

--- a/confidential-data-hub/hub/src/kms/plugins/kbs/mod.rs
+++ b/confidential-data-hub/hub/src/kms/plugins/kbs/mod.rs
@@ -39,7 +39,12 @@ impl RealClient {
 
         let c = match &params.kbc[..] {
             #[cfg(feature = "kbs")]
-            "cc_kbc" => RealClient::Cc(cc_kbc::CcKbc::new(&params.uri).await?),
+            "cc_kbc" => {
+                let aa_socket = env::var("AA_SOCKET").map_err(|e| {
+                    Error::KbsClientError(format!("failed to read AA_SOCKET: {e}"))
+                })?;
+                RealClient::Cc(cc_kbc::CcKbc::new(&params.uri, &aa_socket).await?)
+            }
             #[cfg(feature = "sev")]
             "online_sev_kbc" => RealClient::Sev(sev::OnlineSevKbc::new(&params.uri).await?),
             "offline_fs_kbc" => RealClient::OfflineFs(offline_fs::OfflineFsKbc::new().await?),

--- a/confidential-data-hub/hub/src/kms/plugins/kbs/offline_fs.rs
+++ b/confidential-data-hub/hub/src/kms/plugins/kbs/offline_fs.rs
@@ -18,6 +18,10 @@ use super::{Error, Result};
 const KEYS_PATH: &str = "/etc/aa-offline_fs_kbc-keys.json";
 const RESOURCES_PATH: &str = "/etc/aa-offline_fs_kbc-resources.json";
 
+/// Comma-separated additional resource files loaded after the standard files.
+/// Later files override duplicate resource definitions from earlier files.
+const EXTRA_FILE_PATH_ENV_VAR: &str = "OFFLINE_FS_KBC_EXTRA_FILE_PATH";
+
 pub struct OfflineFsKbc {
     /// Stored resources, loaded from file system
     resources: HashMap<String, Vec<u8>>,
@@ -50,6 +54,14 @@ impl OfflineFsKbc {
 
         res.init_with_file(KEYS_PATH).await?;
         res.init_with_file(RESOURCES_PATH).await?;
+
+        if let Ok(extra_file_paths) = std::env::var(EXTRA_FILE_PATH_ENV_VAR) {
+            for path in extra_file_paths.split(',').map(str::trim) {
+                if !path.is_empty() {
+                    res.init_with_file(path).await?;
+                }
+            }
+        }
 
         Ok(res)
     }
@@ -84,10 +96,34 @@ impl OfflineFsKbc {
 
 #[cfg(test)]
 mod tests {
+    use std::{env, ffi::OsString};
+
+    use base64::{engine::general_purpose::STANDARD, Engine};
     use resource_uri::ResourceUri;
     use rstest::rstest;
+    use serial_test::serial;
 
-    use crate::kms::plugins::kbs::{offline_fs::OfflineFsKbc, Kbc};
+    use crate::kms::plugins::kbs::{
+        offline_fs::{OfflineFsKbc, EXTRA_FILE_PATH_ENV_VAR},
+        Kbc,
+    };
+
+    struct ExtraFilesEnvRestore(Option<OsString>);
+
+    impl ExtraFilesEnvRestore {
+        fn capture() -> Self {
+            Self(env::var_os(EXTRA_FILE_PATH_ENV_VAR))
+        }
+    }
+
+    impl Drop for ExtraFilesEnvRestore {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(value) => env::set_var(EXTRA_FILE_PATH_ENV_VAR, value),
+                None => env::remove_var(EXTRA_FILE_PATH_ENV_VAR),
+            }
+        }
+    }
 
     #[rstest]
     #[tokio::test]
@@ -114,5 +150,115 @@ mod tests {
         };
         let rid = ResourceUri::try_from("kbs+pkcs11:///slot/key/label").unwrap();
         assert!(kbc.get_resource(rid).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn init_with_missing_file_is_noop() {
+        let mut kbc = OfflineFsKbc {
+            resources: Default::default(),
+        };
+        kbc.init_with_file("/no/such/path/resources.json")
+            .await
+            .expect("missing file must not fail");
+        assert!(kbc.resources.is_empty());
+    }
+
+    #[tokio::test]
+    async fn init_with_malformed_json_returns_error() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        tokio::fs::write(file.path(), b"{ not valid json }")
+            .await
+            .unwrap();
+        let mut kbc = OfflineFsKbc {
+            resources: Default::default(),
+        };
+
+        assert!(kbc
+            .init_with_file(file.path().to_str().unwrap())
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn init_with_valid_file_populates_resources() {
+        let content = serde_json::json!({
+            "default/key/1": STANDARD.encode(b"key1"),
+            "default/key/2": STANDARD.encode(b"key2"),
+        })
+        .to_string();
+        let file = tempfile::NamedTempFile::new().unwrap();
+        tokio::fs::write(file.path(), content.as_bytes())
+            .await
+            .unwrap();
+        let mut kbc = OfflineFsKbc {
+            resources: Default::default(),
+        };
+
+        kbc.init_with_file(file.path().to_str().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(kbc.resources.get("default/key/1").unwrap(), b"key1");
+        assert_eq!(kbc.resources.get("default/key/2").unwrap(), b"key2");
+    }
+
+    #[tokio::test]
+    async fn duplicate_resource_is_overridden_by_later_file() {
+        let first = tempfile::NamedTempFile::new().unwrap();
+        let second = tempfile::NamedTempFile::new().unwrap();
+        tokio::fs::write(
+            first.path(),
+            serde_json::json!({"default/key/1": STANDARD.encode(b"first")}).to_string(),
+        )
+        .await
+        .unwrap();
+        tokio::fs::write(
+            second.path(),
+            serde_json::json!({"default/key/1": STANDARD.encode(b"second")}).to_string(),
+        )
+        .await
+        .unwrap();
+        let mut kbc = OfflineFsKbc {
+            resources: Default::default(),
+        };
+
+        kbc.init_with_file(first.path().to_str().unwrap())
+            .await
+            .unwrap();
+        kbc.init_with_file(second.path().to_str().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(kbc.resources.get("default/key/1").unwrap(), b"second");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn new_loads_trimmed_extra_file_list_in_order() {
+        let _restore = ExtraFilesEnvRestore::capture();
+        let first = tempfile::NamedTempFile::new().unwrap();
+        let second = tempfile::NamedTempFile::new().unwrap();
+        tokio::fs::write(
+            first.path(),
+            serde_json::json!({
+                "default/key/extra": STANDARD.encode(b"first"),
+                "default/key/only-first": STANDARD.encode(b"one"),
+            })
+            .to_string(),
+        )
+        .await
+        .unwrap();
+        tokio::fs::write(
+            second.path(),
+            serde_json::json!({"default/key/extra": STANDARD.encode(b"second")}).to_string(),
+        )
+        .await
+        .unwrap();
+        env::set_var(
+            EXTRA_FILE_PATH_ENV_VAR,
+            format!(" {},, {} ", first.path().display(), second.path().display()),
+        );
+
+        let kbc = OfflineFsKbc::new().await.unwrap();
+        assert_eq!(kbc.resources.get("default/key/extra").unwrap(), b"second");
+        assert_eq!(kbc.resources.get("default/key/only-first").unwrap(), b"one");
     }
 }

--- a/confidential-data-hub/hub/src/kms/plugins/mod.rs
+++ b/confidential-data-hub/hub/src/kms/plugins/mod.rs
@@ -76,3 +76,35 @@ pub async fn new_getter(
         ) as Box<dyn Getter>),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::kms::{
+        plugins::{new_decryptor, new_getter},
+        ProviderSettings,
+    };
+
+    #[tokio::test]
+    async fn unsupported_getter_provider_returns_error() {
+        let result = new_getter("no_such_provider", ProviderSettings::default()).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn unsupported_decryptor_provider_returns_error() {
+        let result = new_decryptor("no_such_provider", ProviderSettings::default()).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn empty_getter_provider_returns_error() {
+        let result = new_getter("", ProviderSettings::default()).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn empty_decryptor_provider_returns_error() {
+        let result = new_decryptor("", ProviderSettings::default()).await;
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Align the downstream CDH KBC/configuration core with current upstream behavior while preserving Inclavare compatibility and the OpenAnolis Trustee integration:

- use AA passport tokens for `cc_kbc` and keep the OpenAnolis Trustee API-key path
- accept upstream `[aa].aa_socket` while retaining the legacy top-level `aa_socket`
- preserve `CDH_CONFIG_PATH`; an explicit `--config` path still takes precedence
- initialize idempotent cc/offline KBC clients per consumer, while retaining the downstream-only online-SEV singleton with URI mismatch protection
- load comma-separated `OFFLINE_FS_KBC_EXTRA_FILE_PATH` files in order, with later definitions overriding earlier ones
- configure the default log level through `[log].level`, while preserving `RUST_LOG` precedence
- return errors instead of panicking when KBC/AA environment is incomplete

AWS KMS/Secrets Manager is intentionally not included. Existing `mount_path` behavior is untouched, and the complete `GetResource` error chain is preserved.

## Commit structure

1. `feat(cdh): use AA passport tokens for Trustee access`
2. `refactor(cdh): isolate idempotent KBC clients`
3. `feat(cdh): load additional offline KBC resources`
4. `feat(cdh): configure the default log level`

## Validation

Local (Rust 1.76):

- `cargo test -p confidential-data-hub --features kbs,aliyun,sev,bin`: 50 passed, 4 ignored
- targeted KMS/config tests: 25 KMS tests and 11 config tests passed (4 live Aliyun tests ignored)
- `cargo check -p confidential-data-hub --features sev`
- `cargo check -p confidential-data-hub --no-default-features --features bin,ttrpc`
- production targets pass strict Clippy with `-D warnings`
- `cargo fmt --all -- --check`

Real TDX deployment E2E against OpenAnolis Trustee:

- CDH obtained an AA passport and fetched `kbs+tpm-pca:///certificate`; the returned certificate matched the expected Trustee TPM private CA
- upstream nested `[aa]` configuration and `[log].level = "debug"` worked
- legacy top-level `aa_socket` plus `CDH_CONFIG_PATH` fetched the same resource
- a missing plugin returned the complete RPC/GetResource/KBS/Trustee `PluginNotFound` cause chain
- two OfflineFS extra files loaded in order; later-file override and live per-client reload both passed
- original AA, CDH, KBS, gateway, REST bridge, AS and RVPS services remained active after cleanup
