### PR TITLE
feat(cdh): align sealed-secret signing and verification with upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,12 +1261,17 @@ dependencies = [
  "env_logger 0.11.6",
  "hex",
  "image-rs",
+ "jose-b64",
+ "jose-jwa",
+ "jose-jwk",
+ "jose-jws",
  "kbs-types",
  "kbs_protocol",
  "lazy_static",
  "log",
  "nix 0.29.0",
  "p12",
+ "p256",
  "prost 0.13.4",
  "protos",
  "rand 0.9.2",
@@ -3488,6 +3493,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "jose-b64"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec69375368709666b21c76965ce67549f2d2db7605f1f8707d17c9656801b56"
+dependencies = [
+ "base64ct",
+ "serde",
+ "serde_json",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "jose-jwa"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ab78e053fe886a351d67cf0d194c000f9d0dcb92906eb34d853d7e758a4b3a7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "jose-jwk"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "280fa263807fe0782ecb6f2baadc28dffc04e00558a58e33bfdb801d11fd58e7"
+dependencies = [
+ "jose-b64",
+ "jose-jwa",
+ "p256",
+ "p384",
+ "rsa",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "jose-jws"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d49df4f553a811aa2e378155ade5c7aac0f410086d3010faca127417c1c26"
+dependencies = [
+ "jose-b64",
+ "jose-jwa",
+ "jose-jwk",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -8523,6 +8579,7 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 dependencies = [
+ "serde",
  "zeroize_derive",
 ]
 

--- a/confidential-data-hub/docs/SEALED_SECRET.md
+++ b/confidential-data-hub/docs/SEALED_SECRET.md
@@ -167,6 +167,16 @@ cargo run -p confidential-data-hub --bin secret -- seal \
 Provision only the public JWK at the URI in `--signing-kid`. The private JWK
 must remain with the party creating the sealed secret.
 
+Generate a P-256 keypair with the CLI:
+
+```bash
+cargo run -p confidential-data-hub --bin secret -- keygen \
+    --kid my-signing-key --output-dir ./keys
+```
+
+This writes `my-signing-key-private.json` for signing and
+`my-signing-key-public.json` for provisioning to OpenAnolis Trustee.
+
 Create a Kubernetes secret from the signed output:
 
 ```bash

--- a/confidential-data-hub/docs/SEALED_SECRET.md
+++ b/confidential-data-hub/docs/SEALED_SECRET.md
@@ -140,57 +140,37 @@ BASE64URL(UTF8(JWS Protected Header)) || '.
 We can leverage the ["kid"](https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.4)
 field to specify the public key used to verify this signature.
 
-Signatures for secrets are not yet implemented, but sealed secrets are
-required to have a header and signature. A sealed secret should be of the form
+A public P-256 JWK, identified by a `kid`, must be available to verify the
+ES256 signature. The key can either be provisioned under
+`/run/confidential-containers/cdh/sealed-secret` or retrieved from OpenAnolis
+Trustee when the `kid` is a `kbs://` or `kbs+<plugin>://` Resource URI.
 
-`sealed`.`JWS header`.`JWS body (secret content)`.`signature`
-
-Since signature verification is not yet supported, dummy values
-can be used for the header and signature. A sealed secret could look like this.
-
-```
-secret=sealed.fakejwsheader.ewogICAgInZlcnNpb24iOiAiMC4xLjAiLAogICAgInR5cGUiOiAidmF1bHQiLAogICAgIm5hbWUiOiAia2JzOi8vL2RlZmF1bHQvc2VhbGVkLXNlY3JldC90ZXN0IiwKICAgICJwcm92aWRlciI6ICJrYnMiLAogICAgInByb3ZpZGVyX3NldHRpbmdzIjoge30sCiAgICAiYW5ub3RhdGlvbnMiOiB7fQp9Cg.fakesignature
-```
+Signature verification is enabled by default. During migration only, legacy
+fake-signed values can be accepted by setting
+`skip_sealed_secret_verification = true` in the CDH configuration (or
+`SKIP_SEALED_SECRET_VERIFICATION=true` in the environment). This disables the
+integrity check and should not be used for newly created secrets.
 
 ## Usage in CoCo
 
-You can create a Kubernetes secret from a sealed secret
-and Kata will automatically expose it to your workload.
-
-Start with a sealed secret such as
-```json
-{
-	"version": "0.1.0",
-	"type": "envelope",
-	"provider": "xxx",
-	"key_id": "xxx",
-	"encrypted_key": "ab27dc=",
-	"encrypted_data": "xxx",
-	"wrap_type": "A256GCM",
-	"iv": "xxx",
-	"provider_settings": {
-		...
-	},
-	"annotations": {
-		...
-	}
-}
-```
-
-Encode the payload in BASE64URL
-```
-ewoJInZlcnNpb24iOiAiMC4xLjAiLAoJInR5cGUiOiAiZW52ZWxvcGUiLAoJInByb3ZpZGVyIjogInh4eCIsCgkia2V5X2lkIjogInh4eCIsCgkiZW5jcnlwdGVkX2tleSI6ICJhYjI3ZGM9IiwgCgkiZW5jcnlwdGVkX2RhdGEiOiAieHh4IiwKCSJ3cmFwX3R5cGUiOiAiQTI1NkdDTSIsCgkiaXYiOiAieHh4IiwKCSJhbm5vdGF0aW9ucyI6IHsKCQkiY3J5cHRvX2NvbnRleHQiOiB7CgkJCSJhbGdvcml0aG0iOiAiQTI1NkdDTSIKCQl9LAoJCSJwcm92aWRlcl9zZXR0aW5nIjogewoJCQkia21zX2luc3RhbmNlX2lkIjogInh4eCIKCQl9Cgl9Cn0
-```
-Then add a prefix `sealed.` and JWS header and signature.
-
-```
-sealed.fakejwsheader.ewoJInZlcnNpb24iOiAiMC4xLjAiLAoJInR5cGUiOiAiZW52ZWxvcGUiLAoJInByb3ZpZGVyIjogInh4eCIsCgkia2V5X2lkIjogInh4eCIsCgkiZW5jcnlwdGVkX2tleSI6ICJhYjI3ZGM9IiwgCgkiZW5jcnlwdGVkX2RhdGEiOiAieHh4IiwKCSJ3cmFwX3R5cGUiOiAiQTI1NkdDTSIsCgkiaXYiOiAieHh4IiwKCSJhbm5vdGF0aW9ucyI6IHsKCQkiY3J5cHRvX2NvbnRleHQiOiB7CgkJCSJhbGdvcml0aG0iOiAiQTI1NkdDTSIKCQl9LAoJCSJwcm92aWRlcl9zZXR0aW5nIjogewoJCQkia21zX2luc3RhbmNlX2lkIjogInh4eCIKCQl9Cgl9Cn0.fakesignature
-```
-
-Create a Kubernetes secret
+The `secret` CLI creates signed sealed secrets. For example:
 
 ```bash
-kubectl create secret generic sealed-secret --from-literal='secret=sealed.fakejwsheader.ewoJInZlcnNpb24i...'
+cargo run -p confidential-data-hub --bin secret -- seal \
+    --signing-kid kbs:///default/sealed-signing/my-key \
+    --signing-jwk-path ./my-key-private.json \
+    vault \
+    --resource-uri kbs:///default/secret/my-value \
+    --provider kbs
+```
+
+Provision only the public JWK at the URI in `--signing-kid`. The private JWK
+must remain with the party creating the sealed secret.
+
+Create a Kubernetes secret from the signed output:
+
+```bash
+kubectl create secret generic sealed-secret --from-literal='secret=<sealed-secret>'
 ```
 
 Use this secret in a workload
@@ -213,4 +193,3 @@ Your secret will be provisioned to the `PROTECTED_SECRET` environment variable.
 | aliyun       	     |  [aliyun](kms-providers/alibaba.md)                               	| Alibaba                   |
 | ehsm       	     |  [ehsm](kms-providers/ehsm-kms.md)                              		| Intel                   	|
 | kbs                |                                                                          | CoCo                  |
-

--- a/confidential-data-hub/example.config.json
+++ b/confidential-data-hub/example.config.json
@@ -1,5 +1,6 @@
 {
     "socket": "unix:///run/confidential-containers/cdh.sock",
+    "skip_sealed_secret_verification": false,
     "aa": {
         "aa_socket": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
     },

--- a/confidential-data-hub/example.config.toml
+++ b/confidential-data-hub/example.config.toml
@@ -1,6 +1,9 @@
 # The ttrpc sock of CDH that is used to listen to the requests
 socket = "unix:///run/confidential-containers/cdh.sock"
 
+# Legacy compatibility only. Keep false to verify sealed-secret JWS signatures.
+skip_sealed_secret_verification = false
+
 # The ttrpc socket CDH uses to obtain a passport token from AA.
 # The legacy top-level `aa_socket` setting is also accepted.
 [aa]

--- a/confidential-data-hub/hub/Cargo.toml
+++ b/confidential-data-hub/hub/Cargo.toml
@@ -52,6 +52,10 @@ env_logger = { workspace = true, optional = true }
 image-rs = { path = "../../image-rs", default-features = false, features = [
     "kata-cc-rustls-tls",
 ] }
+jose-b64 = "0.1.2"
+jose-jwa = "0.1.2"
+jose-jwk = "0.1.2"
+jose-jws = "0.1.2"
 kbs_protocol = { path = "../../attestation-agent/kbs_protocol", default-features = false, features = [
     "passport",
     "aa_ttrpc",
@@ -61,6 +65,7 @@ kbs-types.workspace = true
 lazy_static.workspace = true
 log.workspace = true
 p12 = { version = "0.6.3", optional = true }
+p256 = "0.13.2"
 prost = { workspace = true, optional = true }
 protos = { path = "../../protos", default-features = false, optional = true }
 rand.workspace = true

--- a/confidential-data-hub/hub/src/bin/secret_cli.rs
+++ b/confidential-data-hub/hub/src/bin/secret_cli.rs
@@ -18,6 +18,7 @@ use confidential_data_hub::secret::{
 };
 
 use crypto::WrapType;
+use jose_jwk::Jwk;
 use rand::TryRngCore;
 #[cfg(feature = "ehsm")]
 use serde_json::Value;
@@ -42,6 +43,14 @@ struct SealArgs {
     /// Type of the Secret, i.e. `vault` or `envelope`
     #[command(subcommand)]
     r#type: TypeArgs,
+
+    /// KID embedded in the JWS header and used to resolve the verification key.
+    #[arg(long)]
+    signing_kid: String,
+
+    /// Path to a private P-256 JWK used to sign the sealed secret.
+    #[arg(long)]
+    signing_jwk_path: String,
 }
 
 #[derive(Args)]
@@ -58,6 +67,10 @@ struct UnsealArgs {
     /// configuration for connecting to KBS provider
     #[arg(short, long)]
     aa_kbc_params: Option<String>,
+
+    /// Accept a legacy or otherwise unverified sealed secret.
+    #[arg(short, long)]
+    skip_verification: bool,
 }
 
 #[derive(Subcommand)]
@@ -164,8 +177,18 @@ async fn main() {
 async fn unseal_secret(unseal_args: &UnsealArgs) {
     let secret_string = fs::read_to_string(&unseal_args.file_path)
         .await
-        .expect("failed to read sealed secret");
-    let secret = Secret::from_signed_base64_string(secret_string).expect("Failed to parse secret.");
+        .expect("failed to read sealed secret")
+        .trim()
+        .to_string();
+
+    // Signature verification may itself retrieve a key from Trustee, so the
+    // KBC selection must be available before the sealed-secret body is parsed.
+    if let Some(params) = &unseal_args.aa_kbc_params {
+        env::set_var("AA_KBC_PARAMS", params);
+    }
+    let secret = Secret::from_signed_base64_string(secret_string, unseal_args.skip_verification)
+        .await
+        .expect("Failed to parse secret.");
 
     // Setup secret provider
     let secret_provider = match secret.r#type {
@@ -197,9 +220,9 @@ async fn unseal_secret(unseal_args: &UnsealArgs) {
     let blob = secret.unseal().await.expect("unseal failed");
 
     // Write the unsealed secret to the filesystem
-    let output_file_name = Path::new(&format!("{}.unsealed", &unseal_args.file_path)).to_owned();
+    let output_file_name = Path::new(&format!("{}.unsealed", unseal_args.file_path)).to_owned();
     if output_file_name.exists() {
-        panic!("{}", format!("{:?} already exists", &output_file_name));
+        panic!("{}", format!("{output_file_name:?} already exists"));
     }
     let mut output_file = fs::File::create(&output_file_name)
         .await
@@ -212,7 +235,7 @@ async fn unseal_secret(unseal_args: &UnsealArgs) {
 
     println!(
         "unseal success, secret is saved in newly generated file: '{:?}'",
-        &output_file_name
+        output_file_name
     );
 }
 
@@ -279,12 +302,16 @@ async fn seal_secret(seal_args: &SealArgs) {
         }
     };
 
+    let signing_jwk =
+        std::fs::read_to_string(&seal_args.signing_jwk_path).expect("Could not find signing JWK");
+    let signing_jwk: Jwk = serde_json::from_str(&signing_jwk).expect("Could not parse signing JWK");
+
     let secret = Secret {
         version: VERSION.into(),
         r#type: sc,
     };
     let secret_string = secret
-        .to_signed_base64_string()
+        .to_signed_base64_string(signing_jwk, seal_args.signing_kid.clone())
         .expect("failed to serialize secret");
     println!("{secret_string}");
 }

--- a/confidential-data-hub/hub/src/bin/secret_cli.rs
+++ b/confidential-data-hub/hub/src/bin/secret_cli.rs
@@ -5,7 +5,10 @@
 
 use std::{env, path::Path};
 
-use base64::{engine::general_purpose::STANDARD, Engine};
+use base64::{
+    engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+    Engine,
+};
 use clap::{command, Args, Parser, Subcommand};
 #[cfg(feature = "aliyun")]
 use confidential_data_hub::kms::plugins::aliyun::AliyunKmsClient;
@@ -19,6 +22,7 @@ use confidential_data_hub::secret::{
 
 use crypto::WrapType;
 use jose_jwk::Jwk;
+use p256::elliptic_curve::sec1::ToEncodedPoint;
 use rand::TryRngCore;
 #[cfg(feature = "ehsm")]
 use serde_json::Value;
@@ -35,6 +39,9 @@ enum Cli {
 
     /// Unseal the given secret
     Unseal(UnsealArgs),
+
+    /// Generate a P-256 signing keypair in JWK format.
+    Keygen(KeygenArgs),
 }
 
 #[derive(Args)]
@@ -71,6 +78,18 @@ struct UnsealArgs {
     /// Accept a legacy or otherwise unverified sealed secret.
     #[arg(short, long)]
     skip_verification: bool,
+}
+
+#[derive(Args)]
+#[command(author, version, about, long_about = None)]
+struct KeygenArgs {
+    /// Key ID embedded in the generated JWKs.
+    #[arg(long, default_value = "sealed-signing")]
+    kid: String,
+
+    /// Existing directory in which to write the key files.
+    #[arg(long, default_value = ".")]
+    output_dir: String,
 }
 
 #[derive(Subcommand)]
@@ -170,6 +189,9 @@ async fn main() {
         }
         Cli::Seal(seal_args) => {
             seal_secret(&seal_args).await;
+        }
+        Cli::Keygen(keygen_args) => {
+            generate_keys(&keygen_args);
         }
     }
 }
@@ -314,6 +336,78 @@ async fn seal_secret(seal_args: &SealArgs) {
         .to_signed_base64_string(signing_jwk, seal_args.signing_kid.clone())
         .expect("failed to serialize secret");
     println!("{secret_string}");
+}
+
+fn generate_keys(args: &KeygenArgs) {
+    let secret_key = loop {
+        let mut scalar_bytes = [0u8; 32];
+        rand::rngs::OsRng
+            .try_fill_bytes(&mut scalar_bytes)
+            .expect("failed to read randomness");
+        if let Ok(key) = p256::SecretKey::from_slice(&scalar_bytes) {
+            break key;
+        }
+    };
+    let point = secret_key.public_key().to_encoded_point(false);
+
+    let d = URL_SAFE_NO_PAD.encode(secret_key.to_bytes());
+    let x = URL_SAFE_NO_PAD.encode(
+        point
+            .x()
+            .expect("uncompressed point must have x coordinate"),
+    );
+    let y = URL_SAFE_NO_PAD.encode(
+        point
+            .y()
+            .expect("uncompressed point must have y coordinate"),
+    );
+
+    let private_jwk = serde_json::json!({
+        "kty": "EC",
+        "crv": "P-256",
+        "alg": "ES256",
+        "use": "sig",
+        "kid": args.kid,
+        "d": d,
+        "x": x,
+        "y": y,
+    });
+    let public_jwk = serde_json::json!({
+        "kty": "EC",
+        "crv": "P-256",
+        "alg": "ES256",
+        "use": "sig",
+        "kid": args.kid,
+        "x": x,
+        "y": y,
+    });
+
+    let output_dir = Path::new(&args.output_dir);
+    let private_path = output_dir.join(format!("{}-private.json", args.kid));
+    let public_path = output_dir.join(format!("{}-public.json", args.kid));
+    if private_path.exists() {
+        panic!("{private_path:?} already exists");
+    }
+    if public_path.exists() {
+        panic!("{public_path:?} already exists");
+    }
+
+    std::fs::write(
+        &private_path,
+        serde_json::to_string_pretty(&private_jwk).expect("Failed to serialize JWK") + "\n",
+    )
+    .unwrap_or_else(|e| panic!("Failed to write {}: {e}", private_path.display()));
+    std::fs::write(
+        &public_path,
+        serde_json::to_string_pretty(&public_jwk).expect("Failed to serialize JWK") + "\n",
+    )
+    .unwrap_or_else(|e| panic!("Failed to write {}: {e}", public_path.display()));
+
+    println!(
+        "Generated {} and {}",
+        private_path.display(),
+        public_path.display()
+    );
 }
 
 async fn handle_envelope_provider(

--- a/confidential-data-hub/hub/src/config.rs
+++ b/confidential-data-hub/hub/src/config.rs
@@ -112,6 +112,11 @@ pub struct CdhConfig {
 
     pub socket: String,
 
+    /// Disable JWS verification only for migration from legacy fake-signed
+    /// sealed secrets. Verification is enabled by default.
+    #[serde(default)]
+    pub skip_sealed_secret_verification: bool,
+
     pub aa_socket: String,
 
     pub log: LogConfig,
@@ -129,6 +134,9 @@ struct RawCdhConfig {
 
     #[serde(default)]
     socket: Option<String>,
+
+    #[serde(default)]
+    skip_sealed_secret_verification: bool,
 
     /// Upstream configuration form.
     #[serde(default)]
@@ -160,6 +168,7 @@ impl From<RawCdhConfig> for CdhConfig {
             socket: raw
                 .socket
                 .unwrap_or_else(|| DEFAULT_CDH_SOCKET_ADDR.to_string()),
+            skip_sealed_secret_verification: raw.skip_sealed_secret_verification,
             aa_socket,
             log: raw.log,
         }
@@ -191,6 +200,7 @@ impl CdhConfig {
                     kbc: KbsConfig::new()?,
                     credentials: Vec::new(),
                     socket: DEFAULT_CDH_SOCKET_ADDR.into(),
+                    skip_sealed_secret_verification: false,
                     aa_socket: DEFAULT_AA_SOCKET_ADDR.into(),
                     image: ImageConfig::from_kernel_cmdline(),
                     log: LogConfig::default(),
@@ -272,6 +282,9 @@ impl CdhConfig {
         if let Some(kbs_cert) = &self.kbc.kbs_cert {
             env::set_var("KBS_CERT", kbs_cert);
         }
+        if self.skip_sealed_secret_verification {
+            env::set_var("SKIP_SEALED_SECRET_VERIFICATION", "true");
+        }
     }
 }
 
@@ -292,6 +305,7 @@ mod tests {
     #[case(
         r#"
 socket = "unix:///run/confidential-containers/cdh.sock"
+skip_sealed_secret_verification = true
 
 [log]
 level = "debug"
@@ -327,6 +341,7 @@ image_pull_proxy = "http://127.0.0.1:8080"
                 ..Default::default()
             },
             socket: "unix:///run/confidential-containers/cdh.sock".to_string(),
+            skip_sealed_secret_verification: true,
             aa_socket: DEFAULT_AA_SOCKET_ADDR.to_string(),
             log: LogConfig {
                 level: "debug".to_string(),
@@ -367,6 +382,7 @@ name = "offline_fs_kbc"
                 ..Default::default()
         },
         socket: DEFAULT_CDH_SOCKET_ADDR.to_string(),
+        skip_sealed_secret_verification: false,
         aa_socket: DEFAULT_AA_SOCKET_ADDR.to_string(),
         log: LogConfig::default(),
     })
@@ -395,6 +411,7 @@ some_undefined_field = "unknown value"
                 ..Default::default()
         },
         socket: DEFAULT_CDH_SOCKET_ADDR.to_string(),
+        skip_sealed_secret_verification: false,
         aa_socket: DEFAULT_AA_SOCKET_ADDR.to_string(),
         log: LogConfig::default(),
     })
@@ -471,8 +488,10 @@ name = "offline_fs_kbc"
     fn set_configuration_envs_sets_defaults_without_overriding_deployment_values() {
         let old_kbc_params = env::var_os("AA_KBC_PARAMS");
         let old_aa_socket = env::var_os("AA_SOCKET");
+        let old_skip_verification = env::var_os("SKIP_SEALED_SECRET_VERIFICATION");
         env::remove_var("AA_KBC_PARAMS");
         env::remove_var("AA_SOCKET");
+        env::remove_var("SKIP_SEALED_SECRET_VERIFICATION");
 
         let config = CdhConfig {
             kbc: KbsConfig {
@@ -483,6 +502,7 @@ name = "offline_fs_kbc"
             credentials: Vec::new(),
             image: ImageConfig::default(),
             socket: DEFAULT_CDH_SOCKET_ADDR.into(),
+            skip_sealed_secret_verification: true,
             aa_socket: "unix:///run/custom/config-aa.sock".into(),
             log: LogConfig::default(),
         };
@@ -496,6 +516,7 @@ name = "offline_fs_kbc"
             env::var("AA_SOCKET").unwrap(),
             "unix:///run/custom/config-aa.sock"
         );
+        assert_eq!(env::var("SKIP_SEALED_SECRET_VERIFICATION").unwrap(), "true");
 
         env::set_var("AA_KBC_PARAMS", "deployment_kbc::http://kbs.example");
         env::set_var("AA_SOCKET", "unix:///run/custom/deployment-aa.sock");
@@ -517,6 +538,10 @@ name = "offline_fs_kbc"
             Some(value) => env::set_var("AA_SOCKET", value),
             None => env::remove_var("AA_SOCKET"),
         }
+        match old_skip_verification {
+            Some(value) => env::set_var("SKIP_SEALED_SECRET_VERIFICATION", value),
+            None => env::remove_var("SKIP_SEALED_SECRET_VERIFICATION"),
+        }
     }
 
     #[test]
@@ -534,6 +559,7 @@ name = "offline_fs_kbc"
             },
             credentials: Vec::new(),
             socket: DEFAULT_CDH_SOCKET_ADDR.into(),
+            skip_sealed_secret_verification: false,
             aa_socket: DEFAULT_AA_SOCKET_ADDR.into(),
             image: ImageConfig::from_kernel_cmdline(),
             log: LogConfig::default(),

--- a/confidential-data-hub/hub/src/secret/error.rs
+++ b/confidential-data-hub/hub/src/secret/error.rs
@@ -25,4 +25,19 @@ pub enum SecretError {
 
     #[error("parse SealedSecret failed: {0}")]
     ParseFailed(&'static str),
+
+    #[error("Signature Error: {0}")]
+    SignatureError(#[from] p256::ecdsa::Error),
+
+    #[error("JSON Parsing Error: {0}")]
+    JsonError(#[from] serde_json::Error),
+
+    #[error("Signing key error: {0}")]
+    BadSigningKey(&'static str),
+
+    #[error("Failed to get key from KMS: {0}")]
+    KmsError(#[from] crate::kms::Error),
+
+    #[error("IO Operation Failed: {0}")]
+    IoError(#[from] std::io::Error),
 }

--- a/confidential-data-hub/hub/src/secret/mod.rs
+++ b/confidential-data-hub/hub/src/secret/mod.rs
@@ -7,11 +7,24 @@ pub mod error;
 pub mod layout;
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD as b64, Engine};
+use jose_jwa::Signing;
+use jose_jwk::{EcCurves, Jwk};
+use jose_jws::{Flattened, Protected, Unprotected};
+use p256::ecdsa::{
+    signature::{Signer, Verifier},
+    Signature, SigningKey, VerifyingKey,
+};
 use serde::{Deserialize, Serialize};
+use std::fs;
 
 use self::layout::{envelope::EnvelopeSecret, vault::VaultSecret};
+use crate::kms::{self, Annotations, ProviderSettings};
+use resource_uri::ResourceUri;
 
 pub use error::{Result, SecretError};
+
+/// Path containing sealed-secret verification keys provisioned at CDH startup.
+pub const SIGNING_CREDENTIALS_PATH: &str = "/run/confidential-containers/cdh/sealed-secret";
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 #[serde(tag = "type", rename_all = "lowercase")]
@@ -34,7 +47,11 @@ pub async fn unseal_secret(secret: &[u8]) -> Result<Vec<u8>> {
     let secret_string = String::from_utf8(secret.to_vec())
         .map_err(|_| SecretError::ParseFailed("Secret string must be UTF-8"))?;
 
-    let secret = Secret::from_signed_base64_string(secret_string)?;
+    let skip_verification = std::env::var("SKIP_SEALED_SECRET_VERIFICATION")
+        .map(|value| value == "true")
+        .unwrap_or(false);
+
+    let secret = Secret::from_signed_base64_string(secret_string, skip_verification).await?;
     secret.unseal().await
 }
 
@@ -50,19 +67,67 @@ impl Secret {
         }
     }
 
-    // TODO: check the signature
-    pub fn from_signed_base64_string(secret: String) -> Result<Self> {
-        let sections: Vec<_> = secret.split('.').collect();
+    pub async fn from_signed_base64_string(
+        secret: String,
+        skip_verification: bool,
+    ) -> Result<Self> {
+        let payload = if skip_verification {
+            // Legacy fake JWS headers are intentionally accepted only through
+            // this explicit compatibility mode.
+            let sections: Vec<_> = secret.trim().split('.').collect();
+            if sections.len() != 4 || sections[0] != "sealed" {
+                return Err(SecretError::ParseFailed("malformed input sealed secret"));
+            }
 
-        if sections.len() != 4 {
-            return Err(SecretError::ParseFailed("malformed input sealed secret"));
-        }
+            b64.decode(sections[2]).map_err(|_| {
+                SecretError::ParseFailed(
+                    "failed to decode secret body as base64 (URL-safe without padding)",
+                )
+            })?
+        } else {
+            let compact_jws = secret
+                .trim()
+                .strip_prefix("sealed.")
+                .ok_or(SecretError::ParseFailed(
+                    "sealed secret must start with sealed.",
+                ))?
+                .to_string();
 
-        let secret_json = b64
-            .decode(sections[2])
-            .map_err(|_| SecretError::ParseFailed("base64 decode Secret body"))?;
+            let jws: Flattened = compact_jws
+                .parse()
+                .map_err(|_| SecretError::ParseFailed("Failed to parse JWS"))?;
+            let protected = jws
+                .signature
+                .protected
+                .as_ref()
+                .ok_or(SecretError::ParseFailed("Could not find protected header"))?;
+            let kid = protected
+                .oth
+                .kid
+                .as_ref()
+                .ok_or(SecretError::ParseFailed("Could not find kid"))?;
+            let alg = protected
+                .oth
+                .alg
+                .ok_or(SecretError::ParseFailed("Could not get algorithm"))?;
 
-        let secret: Secret = serde_json::from_slice(&secret_json).map_err(|_| {
+            if alg != Signing::Es256 {
+                return Err(SecretError::BadSigningKey("JWS algorithm must be ES256"));
+            }
+
+            let verification_key = Self::get_kid(kid).await?;
+            Self::validate_es256(
+                &compact_jws,
+                &verification_key,
+                jws.signature.signature.as_ref(),
+            )?;
+
+            jws.payload
+                .ok_or(SecretError::ParseFailed("Could not find JWS Payload"))?
+                .to_vec()
+        };
+
+        let secret: Secret = serde_json::from_slice(&payload).map_err(|_| {
             SecretError::ParseFailed(
                 "malformed input sealed secret format (json deserialization failed)",
             )
@@ -71,31 +136,175 @@ impl Secret {
         Ok(secret)
     }
 
-    // TODO: add real signature generation
-    pub fn to_signed_base64_string(&self) -> Result<String> {
+    /// Resolve a verification key from Trustee when `kid` is a Resource URI,
+    /// or from the credentials directory otherwise.
+    async fn get_kid(kid: &str) -> Result<Vec<u8>> {
+        if ResourceUri::try_from(kid).is_ok() {
+            return Ok(kms::new_getter("kbs", ProviderSettings::default())
+                .await?
+                .get_secret(kid, &Annotations::default())
+                .await?);
+        }
+
+        let base = fs::canonicalize(SIGNING_CREDENTIALS_PATH).map_err(|_| {
+            SecretError::ParseFailed("KID is invalid. Must be a KBS URI or a credential path.")
+        })?;
+        let kid_path = fs::canonicalize(base.join(kid))?;
+        if !kid_path.starts_with(&base) {
+            return Err(SecretError::ParseFailed("Invalid KID Key Path"));
+        }
+
+        Ok(tokio::fs::read(kid_path).await?)
+    }
+
+    fn validate_es256(compact_jws: &str, verification_key: &[u8], signature: &[u8]) -> Result<()> {
+        let jwk: Jwk = serde_json::from_slice(verification_key)?;
+        let public_key: p256::PublicKey = match &jwk.key {
+            jose_jwk::Key::Ec(ec) if ec.crv == EcCurves::P256 => ec
+                .try_into()
+                .map_err(|_| SecretError::BadSigningKey("Could not parse verification key."))?,
+            _ => return Err(SecretError::BadSigningKey("Key must be P256")),
+        };
+
+        let mut sections = compact_jws.split('.');
+        let protected = sections
+            .next()
+            .ok_or(SecretError::ParseFailed("Could not find JWS header"))?;
+        let payload = sections
+            .next()
+            .ok_or(SecretError::ParseFailed("Could not find JWS payload"))?;
+        let signing_input = format!("{protected}.{payload}");
+
+        let signature = Signature::from_slice(signature)?;
+        VerifyingKey::from(&public_key).verify(signing_input.as_bytes(), &signature)?;
+        Ok(())
+    }
+
+    pub fn to_signed_base64_string(&self, signing_key: Jwk, signing_kid: String) -> Result<String> {
         let secret_json = serde_json::to_string(&self)
             .map_err(|_| SecretError::ParseFailed("JSON serialization failed"))?;
 
-        let secret_base64 = b64.encode(secret_json);
+        let signing_key: p256::SecretKey = match &signing_key.key {
+            jose_jwk::Key::Ec(ec) if ec.crv == EcCurves::P256 => ec
+                .try_into()
+                .map_err(|_| SecretError::BadSigningKey("Could not parse signing key."))?,
+            _ => {
+                return Err(SecretError::BadSigningKey(
+                    "Key must be EC P256 private key",
+                ))
+            }
+        };
+        let signing_key = SigningKey::from(&signing_key);
 
-        let secret_string = format!("sealed.fakejwsheader.{}.fakesignature", secret_base64);
+        let header = Protected {
+            oth: Unprotected {
+                alg: Some(Signing::Es256),
+                kid: Some(signing_kid),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let header_b64 = b64.encode(serde_json::to_vec(&header)?);
+        let payload_b64 = b64.encode(secret_json.as_bytes());
+        let signing_input = format!("{header_b64}.{payload_b64}");
+        let signature: Signature = signing_key.sign(signing_input.as_bytes());
+        let signature_b64 = b64.encode(signature.to_bytes());
 
-        Ok(secret_string)
+        Ok(format!("sealed.{header_b64}.{payload_b64}.{signature_b64}"))
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::{env, ffi::OsString};
+
     use assert_json_diff::assert_json_eq;
+    use base64::{engine::general_purpose::STANDARD, Engine};
     use crypto::WrapType;
+    use jose_jwk::Jwk;
     use rstest::rstest;
+    use serial_test::serial;
 
     use crate::secret::layout::{
         envelope::EnvelopeSecret,
         vault::{Annotations, ProviderSettings, VaultSecret},
     };
 
-    use super::{Secret, SecretContent};
+    use super::{b64, Secret, SecretContent, SecretError};
+
+    const PRIVATE_JWK: &str = include_str!("./tests/test-key.json");
+    const OTHER_PRIVATE_JWK: &str = include_str!("./tests/test-key-2.json");
+
+    struct EnvRestore {
+        aa_kbc_params: Option<OsString>,
+        extra_resources: Option<OsString>,
+    }
+
+    impl EnvRestore {
+        fn capture() -> Self {
+            Self {
+                aa_kbc_params: env::var_os("AA_KBC_PARAMS"),
+                extra_resources: env::var_os("OFFLINE_FS_KBC_EXTRA_FILE_PATH"),
+            }
+        }
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            match self.aa_kbc_params.take() {
+                Some(value) => env::set_var("AA_KBC_PARAMS", value),
+                None => env::remove_var("AA_KBC_PARAMS"),
+            }
+            match self.extra_resources.take() {
+                Some(value) => env::set_var("OFFLINE_FS_KBC_EXTRA_FILE_PATH", value),
+                None => env::remove_var("OFFLINE_FS_KBC_EXTRA_FILE_PATH"),
+            }
+        }
+    }
+
+    fn signing_key(jwk: &str) -> Jwk {
+        serde_json::from_str(jwk).expect("parse test signing JWK")
+    }
+
+    fn public_jwk(jwk: &str) -> Vec<u8> {
+        let mut value: serde_json::Value = serde_json::from_str(jwk).unwrap();
+        value.as_object_mut().unwrap().remove("d");
+        serde_json::to_vec(&value).unwrap()
+    }
+
+    async fn provision_offline_verification_key(jwk: &str) -> tempfile::NamedTempFile {
+        let resources = tempfile::NamedTempFile::new().unwrap();
+        let content = serde_json::json!({
+            "default/sealed-secret/test-key": STANDARD.encode(public_jwk(jwk)),
+        });
+        tokio::fs::write(resources.path(), content.to_string())
+            .await
+            .unwrap();
+        env::set_var("AA_KBC_PARAMS", "offline_fs_kbc::");
+        env::set_var("OFFLINE_FS_KBC_EXTRA_FILE_PATH", resources.path());
+        resources
+    }
+
+    fn signed(secret: &Secret, jwk: &str) -> String {
+        secret
+            .to_signed_base64_string(
+                signing_key(jwk),
+                "kbs:///default/sealed-secret/test-key".to_string(),
+            )
+            .expect("sign secret")
+    }
+
+    fn vault_secret(name: &str) -> Secret {
+        Secret {
+            version: "0.1.0".into(),
+            r#type: SecretContent::Vault(VaultSecret {
+                provider: "kbs".into(),
+                provider_settings: ProviderSettings::default(),
+                annotations: Annotations::default(),
+                name: name.into(),
+            }),
+        }
+    }
 
     #[rstest]
     #[case(include_str!("./tests/envelope-1.json"), Secret {
@@ -129,21 +338,112 @@ mod tests {
             name: "kbs:///one/2/trois".into(),
         }),
     })]
-    fn serialize_deserialize(#[case] secret_json: &str, #[case] secret_object: Secret) {
+    #[tokio::test]
+    async fn serialize_deserialize(#[case] secret_json: &str, #[case] secret_object: Secret) {
         let serialized = serde_json::to_string_pretty(&secret_object).expect("serialize failed");
         assert_json_eq!(secret_json, serialized);
 
         let parsed: Secret = serde_json::from_str(secret_json).expect("deserialize failed");
         assert_eq!(parsed, secret_object);
 
-        let secret_string = secret_object
-            .to_signed_base64_string()
-            .expect("serialization failed");
-
-        let secret_from_string =
-            Secret::from_signed_base64_string(secret_string).expect("deserialiation failed");
+        let secret_string = signed(&secret_object, PRIVATE_JWK);
+        let secret_from_string = Secret::from_signed_base64_string(secret_string, true)
+            .await
+            .expect("deserialization failed in explicit compatibility mode");
 
         assert_eq!(secret_from_string, secret_object);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn verifies_es256_key_retrieved_through_openanolis_kbs_uri() {
+        let _restore = EnvRestore::capture();
+        let _resources = provision_offline_verification_key(PRIVATE_JWK).await;
+        let secret = vault_secret("kbs:///default/secret/value");
+
+        let parsed = Secret::from_signed_base64_string(signed(&secret, PRIVATE_JWK), false)
+            .await
+            .expect("verification with OfflineFS/OpenAnolis resource URI must pass");
+        assert_eq!(parsed, secret);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn rejects_tampered_payload() {
+        let _restore = EnvRestore::capture();
+        let _resources = provision_offline_verification_key(PRIVATE_JWK).await;
+        let mut sections: Vec<String> =
+            signed(&vault_secret("kbs:///default/secret/value"), PRIVATE_JWK)
+                .split('.')
+                .map(ToString::to_string)
+                .collect();
+        let replacement = if sections[2].starts_with('A') {
+            "B"
+        } else {
+            "A"
+        };
+        sections[2].replace_range(..1, replacement);
+
+        assert!(Secret::from_signed_base64_string(sections.join("."), false)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn rejects_signature_from_wrong_key() {
+        let _restore = EnvRestore::capture();
+        let _resources = provision_offline_verification_key(PRIVATE_JWK).await;
+        let secret = vault_secret("kbs:///default/secret/value");
+
+        assert!(
+            Secret::from_signed_base64_string(signed(&secret, OTHER_PRIVATE_JWK), false)
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_non_es256_algorithm_before_key_lookup() {
+        let mut sections: Vec<String> = signed(&vault_secret("ignored"), PRIVATE_JWK)
+            .split('.')
+            .map(ToString::to_string)
+            .collect();
+        let mut header: serde_json::Value =
+            serde_json::from_slice(&b64.decode(&sections[1]).unwrap()).unwrap();
+        header["alg"] = serde_json::json!("RS256");
+        sections[1] = b64.encode(serde_json::to_vec(&header).unwrap());
+
+        let error = Secret::from_signed_base64_string(sections.join("."), false)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, SecretError::BadSigningKey(_)));
+    }
+
+    #[tokio::test]
+    async fn legacy_fake_signature_requires_explicit_skip() {
+        let secret = vault_secret("kbs:///default/secret/value");
+        let payload = b64.encode(serde_json::to_vec(&secret).unwrap());
+        let legacy = format!("sealed.fakejwsheader.{payload}.fakesignature");
+
+        assert!(Secret::from_signed_base64_string(legacy.clone(), false)
+            .await
+            .is_err());
+        assert_eq!(
+            Secret::from_signed_base64_string(legacy, true)
+                .await
+                .unwrap(),
+            secret
+        );
+    }
+
+    #[test]
+    fn signing_requires_private_p256_key() {
+        let public_key = signing_key(&String::from_utf8(public_jwk(PRIVATE_JWK)).unwrap());
+        let error = vault_secret("ignored")
+            .to_signed_base64_string(public_key, "kid".into())
+            .unwrap_err();
+        assert!(matches!(error, SecretError::BadSigningKey(_)));
     }
 
     #[rstest]
@@ -162,6 +462,6 @@ mod tests {
 
         let serialized = serde_json::to_string_pretty(&secret).unwrap();
 
-        assert!(!serialized.contains("="));
+        assert!(!serialized.contains('='));
     }
 }

--- a/confidential-data-hub/hub/src/secret/tests/test-key-2.json
+++ b/confidential-data-hub/hub/src/secret/tests/test-key-2.json
@@ -1,0 +1,9 @@
+{
+    "kty": "EC",
+    "d": "Mj3WjKn-BI3cvwmy-iI2PFcwdCIil6JQ2qDdFxwWqFI",
+    "use": "sig",
+    "crv": "P-256",
+    "x": "ba6dhVZMQpM00nfC05nss0_5OQofKMQ8QgiXx3qU_1U",
+    "y": "4cLtTuwNiGopbVTbE1oaUyNXPWmRpweTs7DTUdxS6yE",
+    "alg": "ES256"
+}

--- a/confidential-data-hub/hub/src/secret/tests/test-key.json
+++ b/confidential-data-hub/hub/src/secret/tests/test-key.json
@@ -1,0 +1,10 @@
+{
+    "kty": "EC",
+    "d": "7baJLiTk68NcLgYPv05jJvElqoAhbzi1ZWx4OyILUtA",
+    "use": "sig",
+    "crv": "P-256",
+    "kid": "test-key",
+    "x": "QT3_slJmispaOwnAo6hxebXGLRuiveFuRCLpS4j4S4k",
+    "y": "jcDn4N4nRBQ-a7_D3qjqtb6hwOAXh_ve1wvibPSi1G0",
+    "alg": "ES256"
+}

--- a/confidential-data-hub/hub/tests/keygen.rs
+++ b/confidential-data-hub/hub/tests/keygen.rs
@@ -1,0 +1,112 @@
+// Copyright (c) 2024 Red Hat, Inc
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use assert_cmd::Command;
+use base64::{engine::general_purpose::STANDARD, Engine};
+use serde_json::Value;
+use tempfile::TempDir;
+
+/// Generate a keypair, sign a vault secret, obtain both verification key and
+/// secret through the OpenAnolis-compatible OfflineFS KBC, and unseal it.
+#[test]
+fn seal_unseal_vault_e2e() {
+    let tmp = TempDir::new().unwrap();
+    let kid = "e2e-test-key";
+    let signing_key_path = "default/sealed-signing/e2e-test-key";
+    let signing_key_uri = format!("kbs:///{signing_key_path}");
+    let secret_path = "default/sealed-secret/e2e-test";
+    let secret_uri = format!("kbs:///{secret_path}");
+    let plaintext = b"super-secret-value-42";
+
+    Command::cargo_bin("secret")
+        .unwrap()
+        .args(["keygen", "--kid", kid, "--output-dir"])
+        .arg(tmp.path())
+        .assert()
+        .success();
+
+    let private_jwk_path = tmp.path().join(format!("{kid}-private.json"));
+    let public_jwk_path = tmp.path().join(format!("{kid}-public.json"));
+    let private_jwk: Value =
+        serde_json::from_slice(&std::fs::read(&private_jwk_path).unwrap()).unwrap();
+    let public_jwk: Value =
+        serde_json::from_slice(&std::fs::read(&public_jwk_path).unwrap()).unwrap();
+    assert_eq!(private_jwk["kty"], "EC");
+    assert_eq!(private_jwk["crv"], "P-256");
+    assert_eq!(private_jwk["alg"], "ES256");
+    assert!(private_jwk["d"].is_string());
+    assert!(public_jwk.get("d").is_none());
+    assert_eq!(private_jwk["x"], public_jwk["x"]);
+    assert_eq!(private_jwk["y"], public_jwk["y"]);
+
+    // Keygen refuses to overwrite either half of an existing keypair.
+    Command::cargo_bin("secret")
+        .unwrap()
+        .args(["keygen", "--kid", kid, "--output-dir"])
+        .arg(tmp.path())
+        .assert()
+        .failure();
+
+    let resource_file = tmp.path().join("offline-resources.json");
+    let resources: HashMap<String, String> = [
+        (
+            signing_key_path.to_string(),
+            STANDARD.encode(std::fs::read(&public_jwk_path).unwrap()),
+        ),
+        (secret_path.to_string(), STANDARD.encode(plaintext)),
+    ]
+    .into_iter()
+    .collect();
+    std::fs::write(&resource_file, serde_json::to_vec(&resources).unwrap()).unwrap();
+
+    let seal = Command::cargo_bin("secret")
+        .unwrap()
+        .args([
+            "seal",
+            "--signing-kid",
+            &signing_key_uri,
+            "--signing-jwk-path",
+            private_jwk_path.to_str().unwrap(),
+            "vault",
+            "--resource-uri",
+            &secret_uri,
+            "--provider",
+            "kbs",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        seal.status.success(),
+        "seal failed: {}",
+        String::from_utf8_lossy(&seal.stderr)
+    );
+    let sealed = String::from_utf8(seal.stdout)
+        .unwrap()
+        .lines()
+        .find(|line| line.starts_with("sealed."))
+        .expect("seal output must contain a signed secret")
+        .to_string();
+    let sealed_path = tmp.path().join("sealed.txt");
+    std::fs::write(&sealed_path, sealed).unwrap();
+
+    Command::cargo_bin("secret")
+        .unwrap()
+        .env("OFFLINE_FS_KBC_EXTRA_FILE_PATH", &resource_file)
+        .args([
+            "unseal",
+            "--file-path",
+            sealed_path.to_str().unwrap(),
+            "--aa-kbc-params",
+            "offline_fs_kbc::",
+        ])
+        .assert()
+        .success();
+
+    assert_eq!(
+        std::fs::read(tmp.path().join("sealed.txt.unsealed")).unwrap(),
+        plaintext
+    );
+}


### PR DESCRIPTION
## Summary

Align CDH sealed secrets with upstream signing and verification behavior while retaining downstream compatibility and OpenAnolis Trustee resource access:

- sign sealed secrets with ES256 and embed the public verification key
- verify signatures by default before unsealing, supporting both embedded keys and configured local/KBS key URIs
- keep an explicit compatibility switch for legacy unsigned sealed secrets
- add `secret seal --keyfile` and `secret unseal --keyfile` sequencing with complete error propagation
- add `secret keygen` for generating signing key pairs and key-id metadata
- document configuration and CLI workflows

Key URIs continue to resolve through downstream CDH resource handling and OpenAnolis Trustee; AWS KMS/Secrets Manager is not included. `CDH_CONFIG_PATH`, `mount_path`, and the complete `GetResource` error chain remain intact.

## Commit structure

1. `feat(cdh): sign and verify sealed secrets`
2. `feat(cdh): configure sealed secret verification`
3. `feat(cdh): generate sealed secret signing keys`

## Validation

Local (Rust 1.76):

- sealed-secret unit tests cover valid signatures, tampering, wrong keys, unsigned compatibility, local keys and KBS URI keys
- CLI integration tests cover key generation, signed sealing/unsealing, configured verification and failure paths
- CDH ttrpc/grpc build matrices, formatting and strict Clippy passed

Real TDX deployment E2E against OpenAnolis Trustee:

- generated an ES256 key pair in the guest
- sealed and unsealed with local signing/verification keys
- fetched a verification key through the OpenAnolis Trustee-backed KBS resource path and verified/unsealed successfully
- rejected tampered payloads and mismatched keys
- legacy unsigned compatibility mode worked only when explicitly enabled
- original AA, CDH, KBS, gateway, REST bridge, AS and RVPS services were restored and remained active after cleanup
